### PR TITLE
Implement keystone metadata validation before persistence.

### DIFF
--- a/feather-mesh/README.md
+++ b/feather-mesh/README.md
@@ -153,6 +153,7 @@ feather-mesh/
     │   ├── lib.rs         # Library exports
     │   ├── db.rs          # SQLite connection and schema setup
     │   ├── models/        # Domain data structures
+    │   │   ├── metadata/  # Typed metadata values and validation helpers
     │   │   ├── entities/  # Persisted database row models
     │   │   └── new/       # Insertable NewX models
     │   ├── repositories/  # SQL queries and object mapping

--- a/feather-mesh/mesh_core/src/db.rs
+++ b/feather-mesh/mesh_core/src/db.rs
@@ -43,6 +43,8 @@ pub(crate) fn init_schema(conn: &Connection) -> Result<()> {
             description TEXT,
             owner_team_id INTEGER NOT NULL,
             intended_use TEXT,
+            producer TEXT NOT NULL,
+            usage_policy TEXT NOT NULL,
             created_at TEXT NOT NULL DEFAULT (datetime('now')),
             FOREIGN KEY(owner_team_id) REFERENCES teams(team_id) ON DELETE CASCADE
         );
@@ -84,7 +86,6 @@ pub(crate) fn init_schema(conn: &Connection) -> Result<()> {
         CREATE INDEX IF NOT EXISTS idx_lineage_dependencies_downstream_version_id ON lineage_dependencies(downstream_version_id);
         "#,
     )?;
-
     Ok(())
 }
 

--- a/feather-mesh/mesh_core/src/models/README.md
+++ b/feather-mesh/mesh_core/src/models/README.md
@@ -1,9 +1,10 @@
 # Models
 
-The model layer is split by database lifecycle.
+The model layer is split by database lifecycle and domain validation concepts.
 
 ```
 models/
+├── metadata/  # Typed metadata values and validation helpers
 ├── entities/  # Persisted rows returned from the database
 ├── new/       # Insertable NewX structs used before persistence
 └── mod.rs     # Module exports
@@ -12,3 +13,5 @@ models/
 `entities/` contains persisted models such as `DataProduct`, `Metadata`, and `Team`. These include database-managed fields like primary keys and `created_at` timestamps.
 
 `new/` contains insert models such as `NewDataProduct`, `NewMetadata`, and `NewTeam`. These exclude database-managed fields and are intended for database insertion.
+
+`metadata/` contains typed metadata values such as `AssetType`, `DataQuality`, and `AccessClassification`, plus validation helpers used before persistence.

--- a/feather-mesh/mesh_core/src/models/entities/data_product.rs
+++ b/feather-mesh/mesh_core/src/models/entities/data_product.rs
@@ -8,6 +8,8 @@ pub struct DataProduct {
     pub description: Option<String>,
     pub owner_team_id: i64,
     pub intended_use: Option<String>,
+    pub producer: String,
+    pub usage_policy: String,
     pub created_at: NaiveDateTime,
 }
 
@@ -27,6 +29,8 @@ mod tests {
             description: Some("Order facts curated for finance reporting".to_string()),
             owner_team_id: 2,
             intended_use: Some("Monthly reconciliations".to_string()),
+            producer: "Finance Lab".to_string(),
+            usage_policy: "Internal reporting only".to_string(),
             created_at,
         };
 
@@ -36,6 +40,7 @@ mod tests {
         assert!(json.contains("\"product_id\":11"));
         assert!(json.contains("\"name\":\"Orders\""));
         assert!(json.contains("\"owner_team_id\":2"));
+        assert!(json.contains("\"producer\":\"Finance Lab\""));
         assert_eq!(round_trip, product);
     }
 }

--- a/feather-mesh/mesh_core/src/models/entities/data_product_version.rs
+++ b/feather-mesh/mesh_core/src/models/entities/data_product_version.rs
@@ -1,21 +1,24 @@
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 
+use crate::models::{AccessClassification, AssetType, DataQuality};
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DataProductVersion {
     pub version_id: i64,
     pub data_product_id: i64,
     pub version_label: String,
-    pub asset_type: String,
+    pub asset_type: AssetType,
     pub source_path: String,
-    pub data_quality: String,
-    pub classification: Option<String>,
+    pub data_quality: DataQuality,
+    pub classification: Option<AccessClassification>,
     pub created_at: NaiveDateTime,
 }
 
 #[cfg(test)]
 mod tests {
     use super::DataProductVersion;
+    use crate::models::{AccessClassification, AssetType, DataQuality};
     use chrono::NaiveDateTime;
 
     #[test]
@@ -27,10 +30,10 @@ mod tests {
             version_id: 8,
             data_product_id: 3,
             version_label: "2026.03".to_string(),
-            asset_type: "test".to_string(),
+            asset_type: AssetType::Table,
             source_path: "test/data".to_string(),
-            data_quality: "test".to_string(),
-            classification: Some("test".to_string()),
+            data_quality: DataQuality::Qualified,
+            classification: Some(AccessClassification::Internal),
             created_at,
         };
 
@@ -40,6 +43,9 @@ mod tests {
         assert!(json.contains("\"version_id\":8"));
         assert!(json.contains("\"data_product_id\":3"));
         assert!(json.contains("\"version_label\":\"2026.03\""));
+        assert!(json.contains("\"asset_type\":\"table\""));
+        assert!(json.contains("\"data_quality\":\"qualified\""));
+        assert!(json.contains("\"classification\":\"internal\""));
         assert_eq!(round_trip, version);
     }
 }

--- a/feather-mesh/mesh_core/src/models/metadata/access_classification.rs
+++ b/feather-mesh/mesh_core/src/models/metadata/access_classification.rs
@@ -1,0 +1,63 @@
+use serde::{Deserialize, Serialize};
+
+use super::{ValidationError, normalize_token};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccessClassification {
+    Public,
+    Internal,
+    Restricted,
+}
+
+impl AccessClassification {
+    /// Parses and normalizes a supported access classification.
+    pub fn parse(input: &str) -> Result<Self, ValidationError> {
+        match normalize_token(input).as_str() {
+            "public" => Ok(Self::Public),
+            "internal" => Ok(Self::Internal),
+            "restricted" => Ok(Self::Restricted),
+            "" => Err(ValidationError::new(
+                "classification",
+                "must be one of public, internal, or restricted",
+            )),
+            _ => Err(ValidationError::new(
+                "classification",
+                format!(
+                    "unsupported value '{}'; expected public, internal, or restricted",
+                    input
+                ),
+            )),
+        }
+    }
+
+    /// Returns the canonical database/API string for this classification.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Public => "public",
+            Self::Internal => "internal",
+            Self::Restricted => "restricted",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_supported_values() {
+        assert_eq!(
+            AccessClassification::parse("public").unwrap().as_str(),
+            "public"
+        );
+        assert_eq!(
+            AccessClassification::parse("Internal").unwrap().as_str(),
+            "internal"
+        );
+        assert_eq!(
+            AccessClassification::parse("restricted").unwrap().as_str(),
+            "restricted"
+        );
+    }
+}

--- a/feather-mesh/mesh_core/src/models/metadata/asset_type.rs
+++ b/feather-mesh/mesh_core/src/models/metadata/asset_type.rs
@@ -1,0 +1,62 @@
+use serde::{Deserialize, Serialize};
+
+use super::{ValidationError, normalize_token};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssetType {
+    Dataset,
+    Table,
+    File,
+    Directory,
+    ModelArtifact,
+}
+
+impl AssetType {
+    /// Parses and normalizes a supported product version asset type.
+    pub fn parse(input: &str) -> Result<Self, ValidationError> {
+        match normalize_token(input).as_str() {
+            "dataset" => Ok(Self::Dataset),
+            "table" => Ok(Self::Table),
+            "file" => Ok(Self::File),
+            "directory" => Ok(Self::Directory),
+            "model_artifact" => Ok(Self::ModelArtifact),
+            "" => Err(ValidationError::new(
+                "asset_type",
+                "must be one of dataset, table, file, directory, or model_artifact",
+            )),
+            _ => Err(ValidationError::new(
+                "asset_type",
+                format!(
+                    "unsupported value '{}'; expected dataset, table, file, directory, or model_artifact",
+                    input
+                ),
+            )),
+        }
+    }
+
+    /// Returns the canonical database/API string for this asset type.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Dataset => "dataset",
+            Self::Table => "table",
+            Self::File => "file",
+            Self::Directory => "directory",
+            Self::ModelArtifact => "model_artifact",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_supported_values() {
+        assert_eq!(AssetType::parse("dataset").unwrap().as_str(), "dataset");
+        assert_eq!(
+            AssetType::parse("model-artifact").unwrap().as_str(),
+            "model_artifact"
+        );
+    }
+}

--- a/feather-mesh/mesh_core/src/models/metadata/data_quality.rs
+++ b/feather-mesh/mesh_core/src/models/metadata/data_quality.rs
@@ -1,0 +1,70 @@
+use serde::{Deserialize, Serialize};
+
+use super::{ValidationError, normalize_token};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DataQuality {
+    Production,
+    Qualified,
+    Unverified,
+}
+
+impl DataQuality {
+    /// Parses and normalizes a supported data quality tier.
+    pub fn parse(input: &str) -> Result<Self, ValidationError> {
+        match normalize_token(input).as_str() {
+            "production" => Ok(Self::Production),
+            "qualified" => Ok(Self::Qualified),
+            "unverified" => Ok(Self::Unverified),
+            "" => Err(ValidationError::new(
+                "data_quality",
+                "must be one of production, qualified, or unverified",
+            )),
+            _ => Err(ValidationError::new(
+                "data_quality",
+                format!(
+                    "unsupported value '{}'; expected production, qualified, or unverified",
+                    input
+                ),
+            )),
+        }
+    }
+
+    /// Returns the canonical database/API string for this quality tier.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Production => "production",
+            Self::Qualified => "qualified",
+            Self::Unverified => "unverified",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_only_supported_values_and_normalizes_case() {
+        assert_eq!(
+            DataQuality::parse("production").unwrap().as_str(),
+            "production"
+        );
+        assert_eq!(
+            DataQuality::parse(" Qualified ").unwrap().as_str(),
+            "qualified"
+        );
+        assert_eq!(
+            DataQuality::parse("UNVERIFIED").unwrap().as_str(),
+            "unverified"
+        );
+    }
+
+    #[test]
+    fn rejects_legacy_and_blank_values() {
+        for value in ["gold", "silver", "bronze", "test", ""] {
+            assert!(DataQuality::parse(value).is_err());
+        }
+    }
+}

--- a/feather-mesh/mesh_core/src/models/metadata/mod.rs
+++ b/feather-mesh/mesh_core/src/models/metadata/mod.rs
@@ -1,0 +1,26 @@
+//! Domain metadata values and validation helpers.
+//!
+//! This module holds Feather Mesh business rules that are not database row
+//! shapes. The enums define the allowed values for keystone metadata fields,
+//! while the validators normalize or reject user-provided service input before
+//! it reaches the repository layer.
+
+pub mod access_classification;
+pub mod asset_type;
+pub mod data_quality;
+pub mod validation_error;
+pub mod validators;
+
+pub use access_classification::AccessClassification;
+pub use asset_type::AssetType;
+pub use data_quality::DataQuality;
+pub use validation_error::ValidationError;
+pub use validators::{
+    optional_non_blank, required_string, validate_positive_id, validate_product_name,
+    validate_source_reference, validate_version_label,
+};
+
+/// Normalizes free-form enum input before matching allowed values.
+pub(crate) fn normalize_token(input: &str) -> String {
+    input.trim().to_ascii_lowercase().replace('-', "_")
+}

--- a/feather-mesh/mesh_core/src/models/metadata/validation_error.rs
+++ b/feather-mesh/mesh_core/src/models/metadata/validation_error.rs
@@ -1,0 +1,35 @@
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationError {
+    field: &'static str,
+    message: String,
+}
+
+impl ValidationError {
+    /// Creates a validation error tied to a specific metadata field.
+    pub fn new(field: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            field,
+            message: message.into(),
+        }
+    }
+
+    /// Returns the metadata field that failed validation.
+    pub fn field(&self) -> &'static str {
+        self.field
+    }
+
+    /// Returns the validation failure message.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.field, self.message)
+    }
+}
+
+impl std::error::Error for ValidationError {}

--- a/feather-mesh/mesh_core/src/models/metadata/validators.rs
+++ b/feather-mesh/mesh_core/src/models/metadata/validators.rs
@@ -1,0 +1,106 @@
+use super::ValidationError;
+
+/// Requires a non-empty string and returns its trimmed value.
+pub fn required_string(field: &'static str, value: String) -> Result<String, ValidationError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        Err(ValidationError::new(field, "is required"))
+    } else {
+        Ok(trimmed.to_string())
+    }
+}
+
+/// Validates an optional string when it is present.
+pub fn optional_non_blank(
+    field: &'static str,
+    value: Option<String>,
+) -> Result<Option<String>, ValidationError> {
+    value.map(|inner| required_string(field, inner)).transpose()
+}
+
+/// Requires a database identifier to be positive.
+pub fn validate_positive_id(field: &'static str, value: i64) -> Result<i64, ValidationError> {
+    if value > 0 {
+        Ok(value)
+    } else {
+        Err(ValidationError::new(field, "must be greater than zero"))
+    }
+}
+
+/// Validates a user-facing data product name.
+pub fn validate_product_name(value: String) -> Result<String, ValidationError> {
+    let value = required_string("name", value)?;
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | ' '))
+    {
+        Ok(value)
+    } else {
+        Err(ValidationError::new(
+            "name",
+            "must contain only ASCII letters, numbers, spaces, underscores, or hyphens",
+        ))
+    }
+}
+
+/// Validates a product version label.
+pub fn validate_version_label(value: String) -> Result<String, ValidationError> {
+    let value = required_string("version_label", value)?;
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'))
+    {
+        Ok(value)
+    } else {
+        Err(ValidationError::new(
+            "version_label",
+            "must contain only ASCII letters, numbers, dots, underscores, or hyphens",
+        ))
+    }
+}
+
+/// Validates a file path or URI-like source reference.
+pub fn validate_source_reference(value: String) -> Result<String, ValidationError> {
+    let value = required_string("source_path", value)?;
+    if value.contains(char::is_whitespace) {
+        Err(ValidationError::new(
+            "source_path",
+            "must not contain whitespace",
+        ))
+    } else {
+        Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_required_product_fields() {
+        assert_eq!(
+            validate_product_name("Daily Observations".to_string()).unwrap(),
+            "Daily Observations"
+        );
+        assert_eq!(validate_positive_id("owner_team_id", 5).unwrap(), 5);
+        assert!(validate_product_name(" ".to_string()).is_err());
+        assert!(validate_product_name("bad/name".to_string()).is_err());
+        assert!(validate_positive_id("owner_team_id", 0).is_err());
+        assert!(required_string("producer", "Climate Lab".to_string()).is_ok());
+        assert!(required_string("usage_policy", "".to_string()).is_err());
+    }
+
+    #[test]
+    fn validates_required_version_fields() {
+        assert_eq!(
+            validate_version_label("v1.0.0".to_string()).unwrap(),
+            "v1.0.0"
+        );
+        assert!(validate_version_label("v 1".to_string()).is_err());
+        assert_eq!(
+            validate_source_reference("/data/climate.csv".to_string()).unwrap(),
+            "/data/climate.csv"
+        );
+        assert!(validate_source_reference("/data/climate daily.csv".to_string()).is_err());
+    }
+}

--- a/feather-mesh/mesh_core/src/models/mod.rs
+++ b/feather-mesh/mesh_core/src/models/mod.rs
@@ -1,5 +1,7 @@
 pub mod entities;
+pub mod metadata;
 pub mod new;
 
 pub use entities::{DataProduct, DataProductVersion, LineageDependency, Metadata, Team};
+pub use metadata::{AccessClassification, AssetType, DataQuality, ValidationError};
 pub use new::{NewDataProduct, NewDataProductVersion, NewLineageDependency, NewMetadata, NewTeam};

--- a/feather-mesh/mesh_core/src/models/new/data_product.rs
+++ b/feather-mesh/mesh_core/src/models/new/data_product.rs
@@ -6,6 +6,8 @@ pub struct NewDataProduct {
     pub description: Option<String>,
     pub owner_team_id: i64,
     pub intended_use: Option<String>,
+    pub producer: String,
+    pub usage_policy: String,
 }
 
 impl NewDataProduct {
@@ -15,12 +17,16 @@ impl NewDataProduct {
         description: Option<String>,
         owner_team_id: i64,
         intended_use: Option<String>,
+        producer: String,
+        usage_policy: String,
     ) -> Self {
         Self {
             name,
             description,
             owner_team_id,
             intended_use,
+            producer,
+            usage_policy,
         }
     }
 }
@@ -32,12 +38,21 @@ mod tests {
     #[test]
     // Verifies the constructor leaves optional fields unset and preserves input values.
     fn new_data_product_initializes_insert_model_with_optional_fields_to_none() {
-        let product = NewDataProduct::new("Orders".to_string(), None, 5, None);
+        let product = NewDataProduct::new(
+            "Orders".to_string(),
+            None,
+            5,
+            None,
+            "Finance Lab".to_string(),
+            "Internal reporting only".to_string(),
+        );
 
         assert_eq!(product.name, "Orders");
         assert_eq!(product.description, None);
         assert_eq!(product.owner_team_id, 5);
         assert_eq!(product.intended_use, None);
+        assert_eq!(product.producer, "Finance Lab");
+        assert_eq!(product.usage_policy, "Internal reporting only");
     }
 
     #[test]
@@ -48,6 +63,8 @@ mod tests {
             Some("Order facts curated for finance reporting".to_string()),
             5,
             Some("Monthly reconciliations".to_string()),
+            "Finance Lab".to_string(),
+            "Internal reporting only".to_string(),
         );
 
         assert_eq!(

--- a/feather-mesh/mesh_core/src/models/new/data_product_version.rs
+++ b/feather-mesh/mesh_core/src/models/new/data_product_version.rs
@@ -1,13 +1,15 @@
 use serde::{Deserialize, Serialize};
 
+use crate::models::{AccessClassification, AssetType, DataQuality};
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NewDataProductVersion {
     pub data_product_id: i64,
     pub version_label: String,
-    pub asset_type: String,
+    pub asset_type: AssetType,
     pub source_path: String,
-    pub data_quality: String,
-    pub classification: Option<String>,
+    pub data_quality: DataQuality,
+    pub classification: Option<AccessClassification>,
 }
 
 impl NewDataProductVersion {
@@ -15,10 +17,10 @@ impl NewDataProductVersion {
     pub fn new(
         data_product_id: i64,
         version_label: String,
-        asset_type: String,
+        asset_type: AssetType,
         source_path: String,
-        data_quality: String,
-        classification: Option<String>,
+        data_quality: DataQuality,
+        classification: Option<AccessClassification>,
     ) -> Self {
         Self {
             data_product_id,
@@ -34,6 +36,7 @@ impl NewDataProductVersion {
 #[cfg(test)]
 mod tests {
     use super::NewDataProductVersion;
+    use crate::models::{AccessClassification, AssetType, DataQuality};
 
     #[test]
     // Verifies the constructor leaves optional fields unset and preserves input values.
@@ -41,17 +44,17 @@ mod tests {
         let version = NewDataProductVersion::new(
             12,
             "v1.0.0".to_string(),
-            "test".to_string(),
+            AssetType::File,
             "test/data".to_string(),
-            "test".to_string(),
+            DataQuality::Production,
             None,
         );
 
         assert_eq!(version.data_product_id, 12);
         assert_eq!(version.version_label, "v1.0.0");
-        assert_eq!(version.asset_type, "test");
+        assert_eq!(version.asset_type, AssetType::File);
         assert_eq!(version.source_path, "test/data");
-        assert_eq!(version.data_quality, "test");
+        assert_eq!(version.data_quality, DataQuality::Production);
         assert_eq!(version.classification, None);
     }
 
@@ -61,12 +64,12 @@ mod tests {
         let version = NewDataProductVersion::new(
             12,
             "v1.0.0".to_string(),
-            "test".to_string(),
+            AssetType::File,
             "test/data".to_string(),
-            "test".to_string(),
-            Some("internal".to_string()),
+            DataQuality::Production,
+            Some(AccessClassification::Internal),
         );
 
-        assert_eq!(version.classification, Some("internal".to_string()));
+        assert_eq!(version.classification, Some(AccessClassification::Internal));
     }
 }

--- a/feather-mesh/mesh_core/src/repositories/README.md
+++ b/feather-mesh/mesh_core/src/repositories/README.md
@@ -8,6 +8,6 @@ repositories/
 └── mod.rs           # Repository module exports
 ```
 
-Repositories accept `NewX` insert models, execute SQL using a `rusqlite::Connection`, and return persisted entity models.
+Repositories accept `NewX` insert models, execute SQL using a `rusqlite::Connection`, and return persisted entity models. They are also the boundary where typed domain values are converted to and from SQLite text columns.
 
 Keep SQL and database row mapping here, not in `models/` or `services/`.

--- a/feather-mesh/mesh_core/src/repositories/data_product_repository.rs
+++ b/feather-mesh/mesh_core/src/repositories/data_product_repository.rs
@@ -10,13 +10,16 @@ impl DataProductRepository {
     /// Inserts a new data product and returns the persisted data product row with database-managed fields.
     pub fn create(conn: &Connection, input: NewDataProduct) -> Result<DataProduct> {
         conn.execute(
-            "INSERT INTO data_products (name, description, owner_team_id, intended_use)
-             VALUES (?1, ?2, ?3, ?4)",
+            "INSERT INTO data_products
+                (name, description, owner_team_id, intended_use, producer, usage_policy)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
                 input.name,
                 input.description,
                 input.owner_team_id,
-                input.intended_use
+                input.intended_use,
+                input.producer,
+                input.usage_policy
             ],
         )?;
 
@@ -27,7 +30,8 @@ impl DataProductRepository {
     /// Gets a persisted data product by product_id.
     pub fn get_by_id(conn: &Connection, product_id: i64) -> Result<DataProduct> {
         conn.query_row(
-            "SELECT product_id, name, description, owner_team_id, intended_use, created_at
+            "SELECT product_id, name, description, owner_team_id, intended_use,
+                    producer, usage_policy, created_at
              FROM data_products
              WHERE product_id = ?1",
             params![product_id],
@@ -38,7 +42,8 @@ impl DataProductRepository {
     /// Gets all persisted data products ordered by primary key.
     pub fn get_all(conn: &Connection) -> Result<Vec<DataProduct>> {
         let mut query = conn.prepare(
-            "SELECT product_id, name, description, owner_team_id, intended_use, created_at
+            "SELECT product_id, name, description, owner_team_id, intended_use,
+                    producer, usage_policy, created_at
              FROM data_products
              ORDER BY product_id",
         )?;
@@ -57,7 +62,9 @@ impl DataProductRepository {
             description: row.get("description")?,
             owner_team_id: row.get("owner_team_id")?,
             intended_use: row.get("intended_use")?,
-            created_at: parse_naive_datetime(5, created_at)?,
+            producer: row.get("producer")?,
+            usage_policy: row.get("usage_policy")?,
+            created_at: parse_naive_datetime(7, created_at)?,
         })
     }
 }

--- a/feather-mesh/mesh_core/src/repositories/data_product_version_repository.rs
+++ b/feather-mesh/mesh_core/src/repositories/data_product_version_repository.rs
@@ -1,6 +1,9 @@
-use rusqlite::{Connection, Result, Row, params};
+use rusqlite::{Connection, Result, Row, params, types::Type};
 
-use crate::models::{DataProductVersion, NewDataProductVersion};
+use crate::models::{
+    AccessClassification, AssetType, DataProductVersion, DataQuality, NewDataProductVersion,
+    ValidationError,
+};
 
 use super::parse_naive_datetime;
 
@@ -9,6 +12,7 @@ pub struct DataProductVersionRepository;
 impl DataProductVersionRepository {
     /// Inserts a new data product version and returns the persisted version row with database-managed fields.
     pub fn create(conn: &Connection, input: NewDataProductVersion) -> Result<DataProductVersion> {
+        let classification = input.classification.map(|value| value.as_str());
         conn.execute(
             "INSERT INTO data_product_versions
                 (data_product_id, version_label, asset_type, source_path, data_quality, classification)
@@ -16,10 +20,10 @@ impl DataProductVersionRepository {
             params![
                 input.data_product_id,
                 input.version_label,
-                input.asset_type,
+                input.asset_type.as_str(),
                 input.source_path,
-                input.data_quality,
-                input.classification
+                input.data_quality.as_str(),
+                classification
             ],
         )?;
 
@@ -55,16 +59,32 @@ impl DataProductVersionRepository {
     /// Maps database row -> DataProductVersion struct
     fn from_row(row: &Row<'_>) -> Result<DataProductVersion> {
         let created_at: String = row.get("created_at")?;
+        let asset_type: String = row.get("asset_type")?;
+        let data_quality: String = row.get("data_quality")?;
+        let classification: Option<String> = row.get("classification")?;
 
         Ok(DataProductVersion {
             version_id: row.get("version_id")?,
             data_product_id: row.get("data_product_id")?,
             version_label: row.get("version_label")?,
-            asset_type: row.get("asset_type")?,
+            asset_type: parse_domain_value(3, &asset_type, AssetType::parse)?,
             source_path: row.get("source_path")?,
-            data_quality: row.get("data_quality")?,
-            classification: row.get("classification")?,
+            data_quality: parse_domain_value(5, &data_quality, DataQuality::parse)?,
+            classification: classification
+                .map(|value| parse_domain_value(6, &value, AccessClassification::parse))
+                .transpose()?,
             created_at: parse_naive_datetime(7, created_at)?,
         })
     }
+}
+
+/// Converts persisted metadata text into a typed domain value.
+fn parse_domain_value<T>(
+    column_index: usize,
+    value: &str,
+    parse: impl FnOnce(&str) -> Result<T, ValidationError>,
+) -> Result<T> {
+    parse(value).map_err(|err| {
+        rusqlite::Error::FromSqlConversionFailure(column_index, Type::Text, Box::new(err))
+    })
 }

--- a/feather-mesh/mesh_core/src/services/README.md
+++ b/feather-mesh/mesh_core/src/services/README.md
@@ -5,9 +5,10 @@ The service layer defines API-style functions that expose key Feather Mesh workf
 ```
 services/
 ├── registry_service.rs  # Registry workflows built on repositories
+├── requests.rs          # Service request DTOs for CLI-facing workflows
 └── mod.rs               # Service module exports
 ```
 
-Services coordinate repositories and models, returning workflow-level results while hiding persistence details from `mesh_cli`.
+Services validate request DTOs, coordinate repositories and models, and return workflow-level results while hiding persistence details from `mesh_cli`.
 
 Keep CLI-facing workflow functions here, not in repositories or raw database code.

--- a/feather-mesh/mesh_core/src/services/mod.rs
+++ b/feather-mesh/mesh_core/src/services/mod.rs
@@ -1,3 +1,7 @@
 pub mod registry_service;
+pub mod requests;
 
-pub use registry_service::RegistryService;
+pub use registry_service::{RegistryService, ServiceError, ServiceResult};
+pub use requests::{
+    CreateDataProductRequest, CreateDataProductVersionRequest, CreateLineageDependencyRequest,
+};

--- a/feather-mesh/mesh_core/src/services/registry_service.rs
+++ b/feather-mesh/mesh_core/src/services/registry_service.rs
@@ -1,9 +1,62 @@
-use rusqlite::{Connection, Result};
+use std::fmt;
 
-use crate::models::{NewTeam, Team};
-use crate::repositories::TeamRepository;
+use rusqlite::Connection;
+
+use crate::models::metadata::{
+    optional_non_blank, required_string, validate_positive_id, validate_product_name,
+    validate_source_reference, validate_version_label,
+};
+use crate::models::{
+    AccessClassification, AssetType, DataProduct, DataProductVersion, DataQuality,
+    LineageDependency, NewDataProduct, NewDataProductVersion, NewLineageDependency, NewTeam, Team,
+    ValidationError,
+};
+use crate::repositories::{
+    DataProductRepository, DataProductVersionRepository, LineageDependencyRepository,
+    TeamRepository,
+};
+use crate::services::requests::{
+    CreateDataProductRequest, CreateDataProductVersionRequest, CreateLineageDependencyRequest,
+};
 
 // RegistryService exposes API-style registry workflows for `mesh_cli`.
+pub type ServiceResult<T> = Result<T, ServiceError>;
+
+#[derive(Debug)]
+pub enum ServiceError {
+    Validation(ValidationError),
+    Repository(rusqlite::Error),
+}
+
+impl fmt::Display for ServiceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Validation(err) => write!(f, "validation failed: {err}"),
+            Self::Repository(err) => write!(f, "repository operation failed: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for ServiceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Validation(err) => Some(err),
+            Self::Repository(err) => Some(err),
+        }
+    }
+}
+
+impl From<ValidationError> for ServiceError {
+    fn from(value: ValidationError) -> Self {
+        Self::Validation(value)
+    }
+}
+
+impl From<rusqlite::Error> for ServiceError {
+    fn from(value: rusqlite::Error) -> Self {
+        Self::Repository(value)
+    }
+}
 
 // note: `a -> lifetime of the connection reference, ensures registry service does not outlive the db connection it uses
 pub struct RegistryService<'a> {
@@ -17,12 +70,66 @@ impl<'a> RegistryService<'a> {
     }
 
     /// Registers a team in the registry and returns the persisted team.
-    pub fn register_team(&self, name: String) -> Result<Team> {
-        TeamRepository::create(self.conn, NewTeam::new(name))
+    pub fn register_team(&self, name: String) -> ServiceResult<Team> {
+        Ok(TeamRepository::create(self.conn, NewTeam::new(name))?)
     }
 
     /// Returns all teams currently registered in the registry.
-    pub fn list_teams(&self) -> Result<Vec<Team>> {
-        TeamRepository::get_all(self.conn)
+    pub fn list_teams(&self) -> ServiceResult<Vec<Team>> {
+        Ok(TeamRepository::get_all(self.conn)?)
+    }
+
+    /// Registers a data product after validating required keystone metadata.
+    pub fn register_data_product(
+        &self,
+        input: CreateDataProductRequest,
+    ) -> ServiceResult<DataProduct> {
+        let product = NewDataProduct::new(
+            validate_product_name(input.name)?,
+            optional_non_blank("description", input.description)?,
+            validate_positive_id("owner_team_id", input.owner_team_id)?,
+            optional_non_blank("intended_use", input.intended_use)?,
+            required_string("producer", input.producer)?,
+            required_string("usage_policy", input.usage_policy)?,
+        );
+
+        Ok(DataProductRepository::create(self.conn, product)?)
+    }
+
+    /// Registers a data product version after validating version-level metadata.
+    pub fn register_data_product_version(
+        &self,
+        input: CreateDataProductVersionRequest,
+    ) -> ServiceResult<DataProductVersion> {
+        let asset_type: AssetType = AssetType::parse(&input.asset_type)?;
+        let data_quality: DataQuality = DataQuality::parse(&input.data_quality)?;
+        let classification = AccessClassification::parse(&input.classification)?;
+        let version: NewDataProductVersion = NewDataProductVersion::new(
+            validate_positive_id("data_product_id", input.data_product_id)?,
+            validate_version_label(input.version_label)?,
+            asset_type,
+            validate_source_reference(input.source_path)?,
+            data_quality,
+            Some(classification),
+        );
+
+        Ok(DataProductVersionRepository::create(self.conn, version)?)
+    }
+
+    /// Registers an input dependency after validating lineage metadata.
+    pub fn register_lineage_dependency(
+        &self,
+        input: CreateLineageDependencyRequest,
+    ) -> ServiceResult<LineageDependency> {
+        let dependency = NewLineageDependency::new(
+            validate_positive_id("downstream_version_id", input.downstream_version_id)?,
+            validate_source_reference(input.upstream_product_uri)?,
+            input
+                .upstream_version
+                .map(validate_version_label)
+                .transpose()?,
+        );
+
+        Ok(LineageDependencyRepository::create(self.conn, dependency)?)
     }
 }

--- a/feather-mesh/mesh_core/src/services/requests.rs
+++ b/feather-mesh/mesh_core/src/services/requests.rs
@@ -1,0 +1,26 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateDataProductRequest {
+    pub name: String,
+    pub description: Option<String>,
+    pub owner_team_id: i64,
+    pub intended_use: Option<String>,
+    pub producer: String,
+    pub usage_policy: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateDataProductVersionRequest {
+    pub data_product_id: i64,
+    pub version_label: String,
+    pub asset_type: String,
+    pub source_path: String,
+    pub data_quality: String,
+    pub classification: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateLineageDependencyRequest {
+    pub downstream_version_id: i64,
+    pub upstream_product_uri: String,
+    pub upstream_version: Option<String>,
+}

--- a/feather-mesh/mesh_core/tests/repository_tests.rs
+++ b/feather-mesh/mesh_core/tests/repository_tests.rs
@@ -4,7 +4,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use mesh_core::init_db;
 use mesh_core::models::{
-    NewDataProduct, NewDataProductVersion, NewLineageDependency, NewMetadata, NewTeam,
+    AccessClassification, AssetType, DataQuality, NewDataProduct, NewDataProductVersion,
+    NewLineageDependency, NewMetadata, NewTeam,
 };
 use mesh_core::repositories::{
     DataProductRepository, DataProductVersionRepository, LineageDependencyRepository,
@@ -71,6 +72,8 @@ fn repositories_create_get_by_id_and_get_all_full_registry_graph() {
             Some("Daily climate station observations".to_string()),
             team.team_id,
             Some("Operational climate analytics".to_string()),
+            "Climate Lab".to_string(),
+            "Research and operational analytics".to_string(),
         ),
     )
     .expect("Failed to create data product");
@@ -82,6 +85,8 @@ fn repositories_create_get_by_id_and_get_all_full_registry_graph() {
         product.description,
         Some("Daily climate station observations".to_string())
     );
+    assert_eq!(product.producer, "Climate Lab");
+    assert_eq!(product.usage_policy, "Research and operational analytics");
 
     // get_by_id returns the same product by primary key.
     let found_product = DataProductRepository::get_by_id(&conn, product.product_id)
@@ -98,10 +103,10 @@ fn repositories_create_get_by_id_and_get_all_full_registry_graph() {
         NewDataProductVersion::new(
             product.product_id,
             "v1.0.0".to_string(),
-            "table".to_string(),
+            AssetType::Table,
             "/project/feather-mesh/climate/daily".to_string(),
-            "gold".to_string(),
-            Some("internal".to_string()),
+            DataQuality::Production,
+            Some(AccessClassification::Internal),
         ),
     )
     .expect("Failed to create data product version");
@@ -109,7 +114,9 @@ fn repositories_create_get_by_id_and_get_all_full_registry_graph() {
     // Validate the persisted version fields, including database-managed ones.
     assert!(version.version_id > 0);
     assert_eq!(version.data_product_id, product.product_id);
-    assert_eq!(version.classification, Some("internal".to_string()));
+    assert_eq!(version.asset_type, AssetType::Table);
+    assert_eq!(version.data_quality, DataQuality::Production);
+    assert_eq!(version.classification, Some(AccessClassification::Internal));
 
     // get_by_id returns the same version by primary key.
     let found_version = DataProductVersionRepository::get_by_id(&conn, version.version_id)
@@ -188,7 +195,14 @@ fn repositories_preserve_none_for_nullable_insert_fields() {
         .expect("Failed to create team");
     let product = DataProductRepository::create(
         &conn,
-        NewDataProduct::new("Bare Product".to_string(), None, team.team_id, None),
+        NewDataProduct::new(
+            "Bare Product".to_string(),
+            None,
+            team.team_id,
+            None,
+            "Minimal Lab".to_string(),
+            "Internal research use".to_string(),
+        ),
     )
     .expect("Failed to create data product");
     let version = DataProductVersionRepository::create(
@@ -196,9 +210,9 @@ fn repositories_preserve_none_for_nullable_insert_fields() {
         NewDataProductVersion::new(
             product.product_id,
             "v1".to_string(),
-            "file".to_string(),
+            AssetType::File,
             "/tmp/data.csv".to_string(),
-            "bronze".to_string(),
+            DataQuality::Unverified,
             None,
         ),
     )

--- a/feather-mesh/mesh_core/tests/service_tests.rs
+++ b/feather-mesh/mesh_core/tests/service_tests.rs
@@ -3,7 +3,14 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use mesh_core::init_db;
-use mesh_core::services::RegistryService;
+use mesh_core::models::{AccessClassification, AssetType, DataQuality};
+use mesh_core::repositories::{
+    DataProductRepository, DataProductVersionRepository, LineageDependencyRepository,
+};
+use mesh_core::services::{
+    CreateDataProductRequest, CreateDataProductVersionRequest, CreateLineageDependencyRequest,
+    RegistryService, ServiceError,
+};
 use rusqlite::Connection;
 
 // Builds an isolated temporary database path for each test.
@@ -39,6 +46,299 @@ fn registry_service_registers_and_lists_teams() {
 
     let teams = service.list_teams().expect("Failed to list teams");
     assert_eq!(teams, vec![team]);
+
+    fs::remove_file(path).ok();
+}
+
+#[test]
+// Verifies product and version metadata are validated and normalized before persistence.
+fn registry_service_registers_valid_product_and_version_metadata() {
+    let (conn, path) = test_connection();
+    let service = RegistryService::new(&conn);
+
+    let team = service
+        .register_team("Climate".to_string())
+        .expect("Failed to register team");
+    let product = service
+        .register_data_product(CreateDataProductRequest {
+            name: "Daily Observations".to_string(),
+            description: Some("Daily station observations".to_string()),
+            owner_team_id: team.team_id,
+            intended_use: Some("Operational climate analytics".to_string()),
+            producer: "Climate Lab".to_string(),
+            usage_policy: "Research and operational analytics".to_string(),
+        })
+        .expect("Failed to register product");
+
+    assert!(product.product_id > 0);
+    assert_eq!(product.producer, "Climate Lab");
+    assert_eq!(product.usage_policy, "Research and operational analytics");
+
+    let version = service
+        .register_data_product_version(CreateDataProductVersionRequest {
+            data_product_id: product.product_id,
+            version_label: "v1.0.0".to_string(),
+            asset_type: "Table".to_string(),
+            source_path: "/project/feather-mesh/climate/daily".to_string(),
+            data_quality: "Production".to_string(),
+            classification: "Internal".to_string(),
+        })
+        .expect("Failed to register version");
+
+    assert!(version.version_id > 0);
+    assert_eq!(version.asset_type, AssetType::Table);
+    assert_eq!(version.data_quality, DataQuality::Production);
+    assert_eq!(version.classification, Some(AccessClassification::Internal));
+
+    fs::remove_file(path).ok();
+}
+
+#[test]
+// Verifies optional product metadata remains optional, while blank optional strings are rejected.
+fn registry_service_preserves_optional_product_metadata() {
+    let (conn, path) = test_connection();
+    let service = RegistryService::new(&conn);
+
+    let team = service
+        .register_team("Climate".to_string())
+        .expect("Failed to register team");
+    let product = service
+        .register_data_product(CreateDataProductRequest {
+            name: "Daily Observations".to_string(),
+            description: None,
+            owner_team_id: team.team_id,
+            intended_use: None,
+            producer: "Climate Lab".to_string(),
+            usage_policy: "Research and operational analytics".to_string(),
+        })
+        .expect("Failed to register product");
+
+    assert_eq!(product.description, None);
+    assert_eq!(product.intended_use, None);
+
+    let err = service
+        .register_data_product(CreateDataProductRequest {
+            name: "Hourly Observations".to_string(),
+            description: Some(" ".to_string()),
+            owner_team_id: team.team_id,
+            intended_use: None,
+            producer: "Climate Lab".to_string(),
+            usage_policy: "Research and operational analytics".to_string(),
+        })
+        .expect_err("Blank optional description should fail");
+
+    assert!(matches!(err, ServiceError::Validation(_)));
+
+    fs::remove_file(path).ok();
+}
+
+#[test]
+// Verifies invalid product metadata is rejected before repository insertion.
+fn registry_service_rejects_invalid_product_metadata_before_persistence() {
+    let (conn, path) = test_connection();
+    let service = RegistryService::new(&conn);
+
+    let team = service
+        .register_team("Climate".to_string())
+        .expect("Failed to register team");
+    let err = service
+        .register_data_product(CreateDataProductRequest {
+            name: "Daily/Observations".to_string(),
+            description: None,
+            owner_team_id: team.team_id,
+            intended_use: Some("Operational climate analytics".to_string()),
+            producer: "Climate Lab".to_string(),
+            usage_policy: "Research and operational analytics".to_string(),
+        })
+        .expect_err("Invalid product name should fail");
+
+    assert!(matches!(err, ServiceError::Validation(_)));
+    let products = DataProductRepository::get_all(&conn).expect("Failed to list products");
+    assert!(products.is_empty());
+
+    fs::remove_file(path).ok();
+}
+
+#[test]
+// Verifies invalid version metadata is rejected before repository insertion.
+fn registry_service_rejects_invalid_version_metadata_before_persistence() {
+    let (conn, path) = test_connection();
+    let service = RegistryService::new(&conn);
+
+    let team = service
+        .register_team("Climate".to_string())
+        .expect("Failed to register team");
+    let product = service
+        .register_data_product(CreateDataProductRequest {
+            name: "Daily Observations".to_string(),
+            description: None,
+            owner_team_id: team.team_id,
+            intended_use: Some("Operational climate analytics".to_string()),
+            producer: "Climate Lab".to_string(),
+            usage_policy: "Research and operational analytics".to_string(),
+        })
+        .expect("Failed to register product");
+
+    let err = service
+        .register_data_product_version(CreateDataProductVersionRequest {
+            data_product_id: product.product_id,
+            version_label: "v1.0.0".to_string(),
+            asset_type: "table".to_string(),
+            source_path: "/project/feather mesh/climate/daily".to_string(),
+            data_quality: "production".to_string(),
+            classification: "internal".to_string(),
+        })
+        .expect_err("Invalid source path should fail");
+
+    assert!(matches!(err, ServiceError::Validation(_)));
+    let versions = DataProductVersionRepository::get_all(&conn).expect("Failed to list versions");
+    assert!(versions.is_empty());
+
+    fs::remove_file(path).ok();
+}
+
+#[test]
+// Verifies legacy quality tiers are rejected through the service workflow.
+fn registry_service_rejects_legacy_data_quality_tiers() {
+    let (conn, path) = test_connection();
+    let service = RegistryService::new(&conn);
+
+    let team = service
+        .register_team("Climate".to_string())
+        .expect("Failed to register team");
+    let product = service
+        .register_data_product(CreateDataProductRequest {
+            name: "Daily Observations".to_string(),
+            description: None,
+            owner_team_id: team.team_id,
+            intended_use: Some("Operational climate analytics".to_string()),
+            producer: "Climate Lab".to_string(),
+            usage_policy: "Research and operational analytics".to_string(),
+        })
+        .expect("Failed to register product");
+
+    for quality in ["gold", "silver", "bronze"] {
+        let err = service
+            .register_data_product_version(CreateDataProductVersionRequest {
+                data_product_id: product.product_id,
+                version_label: format!("v1-{quality}"),
+                asset_type: "table".to_string(),
+                source_path: format!("/project/feather-mesh/climate/{quality}"),
+                data_quality: quality.to_string(),
+                classification: "internal".to_string(),
+            })
+            .expect_err("Legacy quality tier should fail");
+
+        assert!(matches!(err, ServiceError::Validation(_)));
+    }
+    let versions = DataProductVersionRepository::get_all(&conn).expect("Failed to list versions");
+    assert!(versions.is_empty());
+
+    fs::remove_file(path).ok();
+}
+
+#[test]
+// Verifies input dependency metadata is validated and persisted through the service workflow.
+fn registry_service_registers_valid_input_dependency_metadata() {
+    let (conn, path) = test_connection();
+    let service = RegistryService::new(&conn);
+
+    let team = service
+        .register_team("Climate".to_string())
+        .expect("Failed to register team");
+    let product = service
+        .register_data_product(CreateDataProductRequest {
+            name: "Daily Observations".to_string(),
+            description: None,
+            owner_team_id: team.team_id,
+            intended_use: Some("Operational climate analytics".to_string()),
+            producer: "Climate Lab".to_string(),
+            usage_policy: "Research and operational analytics".to_string(),
+        })
+        .expect("Failed to register product");
+    let version = service
+        .register_data_product_version(CreateDataProductVersionRequest {
+            data_product_id: product.product_id,
+            version_label: "v1.0.0".to_string(),
+            asset_type: "table".to_string(),
+            source_path: "/project/feather-mesh/climate/daily".to_string(),
+            data_quality: "production".to_string(),
+            classification: "internal".to_string(),
+        })
+        .expect("Failed to register version");
+
+    let dependency = service
+        .register_lineage_dependency(CreateLineageDependencyRequest {
+            downstream_version_id: version.version_id,
+            upstream_product_uri: "mesh://upstream-climate".to_string(),
+            upstream_version: Some("v2.1".to_string()),
+        })
+        .expect("Failed to register input dependency");
+
+    assert!(dependency.dependency_id > 0);
+    assert_eq!(dependency.downstream_version_id, version.version_id);
+    assert_eq!(dependency.upstream_product_uri, "mesh://upstream-climate");
+    assert_eq!(dependency.upstream_version, Some("v2.1".to_string()));
+
+    fs::remove_file(path).ok();
+}
+
+#[test]
+// Verifies invalid identifiers and dependency fields are rejected before repository insertion.
+fn registry_service_rejects_invalid_ids_and_dependencies_before_persistence() {
+    let (conn, path) = test_connection();
+    let service = RegistryService::new(&conn);
+
+    let product_err = service
+        .register_data_product(CreateDataProductRequest {
+            name: "Daily Observations".to_string(),
+            description: None,
+            owner_team_id: 0,
+            intended_use: Some("Operational climate analytics".to_string()),
+            producer: "Climate Lab".to_string(),
+            usage_policy: "Research and operational analytics".to_string(),
+        })
+        .expect_err("Invalid owner_team_id should fail");
+
+    assert!(matches!(product_err, ServiceError::Validation(_)));
+    assert!(
+        DataProductRepository::get_all(&conn)
+            .expect("Failed to list products")
+            .is_empty()
+    );
+
+    let version_err = service
+        .register_data_product_version(CreateDataProductVersionRequest {
+            data_product_id: -1,
+            version_label: "v1.0.0".to_string(),
+            asset_type: "table".to_string(),
+            source_path: "/project/feather-mesh/climate/daily".to_string(),
+            data_quality: "production".to_string(),
+            classification: "internal".to_string(),
+        })
+        .expect_err("Invalid data_product_id should fail");
+
+    assert!(matches!(version_err, ServiceError::Validation(_)));
+    assert!(
+        DataProductVersionRepository::get_all(&conn)
+            .expect("Failed to list versions")
+            .is_empty()
+    );
+
+    let dependency_err = service
+        .register_lineage_dependency(CreateLineageDependencyRequest {
+            downstream_version_id: 0,
+            upstream_product_uri: "mesh://upstream climate".to_string(),
+            upstream_version: Some("v 2".to_string()),
+        })
+        .expect_err("Invalid dependency metadata should fail");
+
+    assert!(matches!(dependency_err, ServiceError::Validation(_)));
+    assert!(
+        LineageDependencyRepository::get_all(&conn)
+            .expect("Failed to list dependencies")
+            .is_empty()
+    );
 
     fs::remove_file(path).ok();
 }


### PR DESCRIPTION
- Added typed metadata validation for asset type, data quality, and access classification -> `mesh_core/models/metadata/*`.
- Added service request DTOs and validation before persistence -> `mesh_core/services/requests.rs`.
- Extended product metadata with `producer` and `usage_policy`.
- Normalized `data_quality` to `production`, `qualified`, or `unverified`.
- Updated repositories/tests for typed metadata and invalid metadata cases.