### PR TITLE
Implement mesh CLI workflows

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,17 @@
+language: "en-US"
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  review_details: false
+  auto_review:
+    enabled: true
+    base_branches:
+      - ".*"
+    drafts: false
+
+chat:
+  auto_reply: true

--- a/docs/feam_pdd.md
+++ b/docs/feam_pdd.md
@@ -27,7 +27,7 @@ A data product is a reusable, versioned asset (or asset set) plus keystone metad
 Feather Mesh supports registration of single files, structured directories, logical collections, model artifacts (for example checkpoints or packaged weights), report artifacts (for example PDF/HTML bundles), and manifest-backed virtual assets that reference many underlying objects.
 
 ### 4.3 Keystone metadata
-Keystone metadata is the minimum metadata set required for reliable discovery and safe reuse. Required fields are `product_id`, `name`, `asset_type`, `owner_team`, `producer`, `created_at`, `version`, `source_path` (or source reference), `intended_use`, `input_dependencies` (empty list allowed), `license_or_usage_policy`, `access_classification`, and `data_quality`.
+Keystone metadata is the minimum metadata set required for reliable discovery and safe reuse. Required fields are `product_id`, `name`, `asset_type`, `owner_team`, `producer`, `created_at`, `version`, `source_path` (or source reference), `intended_use`, `input_dependencies` (empty list allowed), `usage_policy`, version-level `classification`, and `data_quality`.
 
 The `data_quality` field uses a fixed three-tier model: `production` (highest confidence), `qualified` (appropriate to use with caveats), and `unverified` (quality cannot be guaranteed).
 

--- a/docs/feam_pdd.md
+++ b/docs/feam_pdd.md
@@ -1,0 +1,128 @@
+# Feather Mesh Product Definition Document (PDD)
+
+## 1. Purpose and Overview
+High Performance Computing (HPC) environments generate high-value datasets, model artifacts, and analysis outputs across many teams. In most organizations, those outputs are hard to discover and reuse because they are distributed across team-owned storage locations, named inconsistently, and documented unevenly.
+
+Feather Mesh (`feam`) is an HPC-native middleware layer that standardizes how teams publish, discover, and consume reusable data products without forcing teams to give up ownership of their data. It is intended to reduce duplicated work, improve cross-team interoperability, and make pipelines more reliable by replacing ad hoc path conventions with a governed product catalog and deterministic retrieval workflows.
+
+## 2. Why Feather Mesh Instead of Shared Paths, Shared Filesystems, or Wiki Documentation
+Shared filesystems are necessary infrastructure, but they only provide storage and transport. They do not provide standardized metadata, stable discovery interfaces, version selection rules, or consistent provenance visibility. As a result, users can access files but still cannot confidently determine which asset is fit for downstream use.
+
+Wiki-style documentation helps with human context, but it is not a reliable system of record for automation. Documentation can drift from actual outputs, is rarely validated against current assets, and is difficult to query with strict filters inside production workflows.
+
+Feather Mesh adds the missing coordination layer on top of existing storage systems: producers publish data products with required metadata, consumers discover products through queryable metadata, and pipelines resolve product references deterministically.
+
+## 3. Scope, Boundaries, and Non-Goals
+In this document, middleware means a coordination layer between data-producing workflows and data-consuming users or workflows. Feather Mesh registers reusable outputs as data products, stores and indexes metadata, and resolves product references to retrievable assets.
+
+Feather Mesh catalogs products and metadata, provides discovery and retrieval resolution, and validates publication metadata against governance rules. Access enforcement remains delegated to the underlying filesystem. Feather Mesh does not replace enterprise storage systems, does not act as a heavy transformation engine, and does not guarantee scientific correctness of the underlying content.
+
+Non-goals for V1 include building a universal data lake, replacing schedulers or workflow orchestrators, serving as a general documentation platform, and eliminating team autonomy over raw storage layout.
+
+## 4. Core Definitions
+### 4.1 Data product
+A data product is a reusable, versioned asset (or asset set) plus keystone metadata that allows another user or pipeline to understand, discover, trust, and consume it without direct producer involvement.
+
+### 4.2 Supported asset types
+Feather Mesh supports registration of single files, structured directories, logical collections, model artifacts (for example checkpoints or packaged weights), report artifacts (for example PDF/HTML bundles), and manifest-backed virtual assets that reference many underlying objects.
+
+### 4.3 Keystone metadata
+Keystone metadata is the minimum metadata set required for reliable discovery and safe reuse. Required fields are `product_id`, `name`, `asset_type`, `owner_team`, `producer`, `created_at`, `version`, `source_path` (or source reference), `intended_use`, `input_dependencies` (empty list allowed), `license_or_usage_policy`, `access_classification`, and `data_quality`.
+
+The `data_quality` field uses a fixed three-tier model: `production` (highest confidence), `qualified` (appropriate to use with caveats), and `unverified` (quality cannot be guaranteed).
+
+Optional metadata can include domain tags, region or program context, model family, performance summary, retention notes, and contact channels. To increase adoption and consistency, Feather Mesh auto-extracts as much low-risk technical metadata as possible, such as file size, checksum, format, basic schema signatures, and timestamps. Manual input is reserved for high-context fields such as intended use, caveats, and policy interpretations.
+
+### 4.4 Technical meaning of core actions
+In Feather Mesh terminology, serving means registering and publishing a data product with metadata and policy controls. Consuming means resolving a product reference and retrieving or mounting the associated asset for downstream usage. Retrieval is the materialization step into a local path or workflow workspace, while discovery is search and filtering across catalog entries by metadata, policy, and relevance.
+
+## 5. Users, Roles, and Access Controls
+Feather Mesh is designed for data producers (research and engineering teams, including automated workflows), data consumers (analysts, modelers, and downstream pipelines), and platform governance operators.
+
+The role model includes producer, consumer, maintainer, and admin. Serving and consuming are not exclusive; the same principal can hold both producer and consumer responsibilities. Producers can publish products in owned namespaces, consumers can discover and retrieve products allowed by policy, maintainers can manage schema and lifecycle rules, and admins hold platform-level operational authority.
+
+Access control enforcement is delegated to the underlying filesystem permissions model. Feather Mesh does not override filesystem ACLs, POSIX ownership, or group-level access rules; it resolves and surfaces only what the caller is already permitted to access through the filesystem.
+
+Cross-group sharing is implemented through filesystem-native linking patterns. For example, if Group A wants to share a product with Group B, Group A exposes a directory within its workspace to Group B using a symbolic link workflow and grants Group B read and execute permissions on the shared target directory. Feather Mesh then catalogs and serves references to that shared location, but effective access remains determined by filesystem permissions.
+
+Governance still requires ownership and usage-policy metadata, audit logging for critical actions, and explicit `data_quality` assignment. Promotion to `data_quality=production` is self-certified by producer role in V1, while maintainers and admins can audit or correct metadata state when governance violations are identified.
+
+## 6. Metadata and Discoverability
+Feather Mesh uses a structured schema spanning identity, technical descriptors, governance fields, and reuse context. At serve time, keystone metadata is mandatory and validated before catalog publication.
+
+The metadata source of truth is a central registry backed by a catalog database. A derived search index supports V1 keyword and faceted search. Semantic retrieval is explicitly out of scope for V1 and planned as a later capability. Metadata snapshots are tied to product versions so consumers can inspect what was known at publish time.
+
+Keystone metadata aligns to a Feather Mesh DCAT profile, meaning DCAT-aligned core fields are extended with HPC-specific metadata required for practical reuse and governance. Metadata is considered sufficient when a new consumer can determine what the asset is, whether it is the right version and quality tier, whether they are authorized to use it, and how to retrieve it safely.
+
+## 7. Versioning and Lineage
+Feather Mesh supports explicit versioning. A new version is required when underlying content changes, dependency inputs change, processing logic materially changes outcomes, or critical interpretation/policy metadata changes.
+
+Published versions are immutable. Superseding a version requires publishing a new one. Older versions may be archived but remain referenceable for reproducibility unless policy mandates removal.
+
+Lineage tracks upstream product dependencies, producer identity, workflow context, and publication timing. Consumers can inspect provenance before retrieval. Reproducibility is a core objective for production-grade use, so pinned version references are recommended in automation while floating references such as `latest` are limited to exploratory workflows.
+
+## 8. User Flows (Serving and Consuming)
+In the serving flow, a producer selects an asset path or reference, provides required metadata, passes policy and schema validation, and publishes a version that becomes discoverable to users who already have filesystem permissions to access it.
+
+In the consuming flow, a consumer searches by query and metadata filters, inspects version and lineage context, resolves a product identifier, and retrieves a concrete version into a downstream workspace.
+
+## 9. Data Architecture and Persistence
+Feather Mesh primarily registers metadata and asset references while keeping source data in existing storage systems. V1 default consumption behavior is managed-copy, which stages data into approved locations for downstream processing. This default is required in environments where cross-lab directory permissions are limited to read/execute and direct dependency on remote paths is operationally fragile.
+
+Reference-only retrieval can exist as a policy-controlled mode, but it is not the default. Metadata remains the source of truth in the central catalog, while physical asset truth remains in underlying storage systems.
+
+Client-side responsibilities are handled by the `feam` CLI, and service-side responsibilities are handled by the metadata registry API, search/index services, and policy/audit components.
+
+## 10. HPC Environment and Deployment Assumptions
+For this PDD, “same HPC environment” means users and workflows operate under a shared trust and governance domain with compatible identity, scheduler, and storage assumptions.
+
+V1 deployment scope is intentionally narrow: single cluster and single filesystem only. Multi-cluster and cross-filesystem retrieval are out of scope for V1.
+
+Feather Mesh is scheduler-agnostic at interface level and can be invoked from Slurm, PBS, LSF, or scheduler-independent runners. Storage assumptions for V1 are POSIX-like semantics within the chosen filesystem implementation.
+
+## 11. Security, Compliance, and Auditability
+Security is based on least-privilege filesystem permissions, with Feather Mesh inheriting the effective access of the caller at retrieval time. Compliance posture requires policy metadata on publication and audit trails for publish, read, and metadata mutation actions. Retention and archival requirements are represented through metadata and lifecycle controls.
+
+## 12. Reliability and Operations
+Operationally, catalog operations should be idempotent where possible, and retrieval should support retry and checkpoint-aware execution to fit HPC job behavior. The platform should degrade gracefully so metadata discovery remains available even when individual storage endpoints are temporarily unavailable.
+
+## 13. Success Metrics
+Success is measured by adoption and outcome signals such as product publication volume, cross-team consumption rate, reduction in duplicated outputs, and time-to-discovery for reusable artifacts. Quality signals include completeness of keystone metadata, proportion of production pipelines using pinned versions, and retrieval failure rates by cause class.
+
+## 14. Risks and Mitigations
+Primary risks include metadata drift, policy complexity, user friction during serving, and trust gaps during discovery. Mitigation relies on strict required fields, schema validation, template-driven defaults, high auto-extraction coverage, clear lineage visibility, and consistent use of `data_quality` semantics.
+
+## 15. CLI and User Experience
+The CLI is designed as one command surface for both human interaction and automation. Interactive usage supports guided metadata entry and discovery refinement. Non-interactive usage supports deterministic execution with explicit parameters and machine-readable output.
+
+Core command surface (target design):
+- `feam serve <path> --name <name> --asset-type <type> [flags]`
+- `feam search <query> [--filter key=value]`
+- `feam show <product_id> [--version <v>]`
+- `feam consume <product_id> --version <v> --out <path>`
+- `feam lineage <product_id> [--version <v>]`
+- `feam validate-metadata <metadata_file>`
+
+Example usage:
+```bash
+# Serve a directory artifact
+feam serve /data/team_a/yield_model/v3 \
+  --name yield_model_training_output \
+  --asset-type model_artifact \
+  --owner-team team_a \
+  --intended-use "Regional yield forecasting"
+
+# Discover products
+feam search "yield forecast" --filter data_quality=production
+
+# Inspect lineage before use
+feam lineage product://team_a/yield_model --version 3.1.0
+
+# Consume a pinned version into pipeline workspace
+feam consume product://team_a/yield_model --version 3.1.0 --out ./inputs/yield_model
+```
+
+Manual input should be minimal for repeated and pipeline-based operations through defaults and templates, while still requiring enough human context at first publication to preserve reuse quality.
+
+## 16. Finalized V1 Decisions
+`production` promotion is self-certified by producer role via the `data_quality` keystone attribute. The `data_quality` tiers are `production`, `qualified`, and `unverified`. Default consume mode is managed-copy. V1 search is metadata-driven keyword and filter search only. V1 deployment is single cluster and single filesystem. Keystone metadata aligns to a Feather Mesh DCAT profile with strong auto-extraction to increase adoption and baseline metadata quality.

--- a/docs/project_exit_outcomes.md
+++ b/docs/project_exit_outcomes.md
@@ -33,8 +33,8 @@ Exit outcomes:
   - `source_path` or source reference
   - `intended_use`
   - `input_dependencies`
-  - `license_or_usage_policy`
-  - `access_classification`
+  - `usage_policy`
+  - version-level `classification`
   - `data_quality`
 - `data_quality` accepts only `production`, `qualified`, and `unverified`.
 - Invalid quality labels such as `gold`, `silver`, or `bronze` are rejected.
@@ -213,4 +213,3 @@ Exit outcomes:
 - Pinned version consumption is demonstrated.
 - Retrieval failures can be categorized by cause class.
 - The project can explain how V1 reduces reliance on ad hoc paths, stale wiki documentation, and producer-to-consumer manual handoff.
-

--- a/docs/project_exit_outcomes.md
+++ b/docs/project_exit_outcomes.md
@@ -1,0 +1,216 @@
+# Feather Mesh Project Exit Outcomes
+
+Source: `feam_pdd.md`
+
+These outcomes define what the project must demonstrate at exit to be considered a successful V1 delivery. They are written as observable product outcomes rather than implementation tasks.
+
+## 1. Publish Reusable Data Products
+
+Feather Mesh must allow a producer to publish a reusable asset as a versioned data product without moving ownership of the underlying files.
+
+Exit outcomes:
+
+- A producer can run `feam serve <path>` against a POSIX-like filesystem path.
+- The published product records an identity, name, asset type, owner team, producer, created timestamp, version, and source path or source reference.
+- Supported asset categories include at least files, directories, model artifacts, report artifacts, and manifest-backed collections at the metadata level.
+- Publication fails before persistence when required keystone metadata is missing or invalid.
+- Product publication keeps source data in its original storage location.
+
+## 2. Enforce Keystone Metadata Quality
+
+Feather Mesh must make metadata completeness a hard product requirement rather than optional documentation.
+
+Exit outcomes:
+
+- The required keystone metadata contract is represented in code and tests:
+  - `product_id`
+  - `name`
+  - `asset_type`
+  - `owner_team`
+  - `producer`
+  - `created_at`
+  - `version`
+  - `source_path` or source reference
+  - `intended_use`
+  - `input_dependencies`
+  - `license_or_usage_policy`
+  - `access_classification`
+  - `data_quality`
+- `data_quality` accepts only `production`, `qualified`, and `unverified`.
+- Invalid quality labels such as `gold`, `silver`, or `bronze` are rejected.
+- A user can validate metadata independently through `feam validate-metadata <metadata_file>`.
+- Metadata validation errors are specific enough for a producer to fix without reading source code.
+
+## 3. Provide Deterministic Discovery
+
+Feather Mesh must let consumers find reusable assets through structured catalog metadata instead of ad hoc filesystem path knowledge.
+
+Exit outcomes:
+
+- A consumer can run `feam search <query>` and receive matching products from the local registry.
+- Search supports deterministic filters for fields such as asset type, owner team, data quality, access classification, and metadata key/value pairs.
+- Search behavior is metadata-driven keyword and faceted search only; semantic retrieval is not required for V1.
+- Empty, single-result, and multi-result searches are handled explicitly.
+- Search results expose enough summary information for a consumer to decide whether to inspect a product.
+
+## 4. Inspect Products, Versions, and Reuse Context
+
+Feather Mesh must allow consumers to understand what a product is before retrieving it.
+
+Exit outcomes:
+
+- A consumer can run `feam show <product_id>` to inspect product metadata.
+- A consumer can pin inspection to a version with `feam show <product_id> --version <v>`.
+- Product inspection shows identity, owner, producer, asset type, version, source reference, intended use, policy metadata, access classification, and data quality.
+- Metadata snapshots are tied to product versions so consumers can inspect what was known at publish time.
+- Product summaries are assembled through service workflows rather than direct CLI repository access.
+
+## 5. Support Explicit Versioning and Immutable Published Versions
+
+Feather Mesh must support reproducible use of published assets through explicit version references.
+
+Exit outcomes:
+
+- A product can have one or more explicit versions.
+- Publishing a changed asset, changed dependency, changed processing logic, or critical metadata update creates a new version.
+- Published versions are immutable through the V1 workflow.
+- Older versions remain referenceable unless removed by explicit policy.
+- Automation can use pinned product/version references instead of relying on floating path conventions.
+
+## 6. Surface Lineage and Dependency Context
+
+Feather Mesh must expose provenance enough for consumers to evaluate trust and reuse risk.
+
+Exit outcomes:
+
+- A producer can attach upstream input dependencies to a product version.
+- A consumer can run `feam lineage <product_id>` and inspect upstream dependencies and publication context.
+- A consumer can request lineage for a specific version with `--version <v>`.
+- Lineage includes producer identity, upstream product or source references where available, and publication timing.
+- Missing lineage is represented explicitly rather than silently omitted.
+
+## 7. Consume Products Through Managed Copy
+
+Feather Mesh must implement the V1 default retrieval mode as managed copy into a downstream workspace.
+
+Exit outcomes:
+
+- A consumer can run `feam consume <product_id> --version <v> --out <path>`.
+- Consumption resolves the product/version reference to a concrete source path.
+- Consumption checks that the source exists and is readable through the caller's filesystem permissions.
+- Files and directories can be copied to the requested output path.
+- Existing output paths are not overwritten unless an explicit overwrite flag is provided.
+- A receipt or equivalent metadata artifact is written with product id, version, source path, retrieval timestamp, and checksum where available.
+- Reference-only retrieval is not the default V1 behavior.
+
+## 8. Preserve Filesystem-Native Access Boundaries
+
+Feather Mesh must coordinate discovery and retrieval without replacing the HPC filesystem security model.
+
+Exit outcomes:
+
+- Feather Mesh does not bypass POSIX permissions, filesystem ACLs, ownership, or group access rules.
+- Products resolve only to paths the caller can access through the underlying filesystem.
+- Permission failures produce actionable errors.
+- Cross-team sharing remains compatible with filesystem-native linking and permission workflows.
+- Access classification is recorded as metadata and does not imply filesystem access by itself.
+
+## 9. Provide a CLI Surface Suitable for Humans and Automation
+
+Feather Mesh must deliver a CLI-first V1 workflow that works in scripted HPC jobs.
+
+Exit outcomes:
+
+- `feam --help` shows the V1 command surface:
+  - `serve`
+  - `search`
+  - `show`
+  - `consume`
+  - `lineage`
+  - `validate-metadata`
+- Each core command supports non-interactive execution with explicit parameters.
+- Machine-readable output such as `--json` is available where practical for automation.
+- CLI parsing and terminal UX remain in `mesh_cli`.
+- Business workflows remain in `mesh_core::services`.
+- CLI-facing workflows do not call repositories directly.
+
+## 10. Maintain a Local Registry Source of Truth
+
+Feather Mesh must keep catalog metadata in a queryable registry that is usable within the V1 single-cluster scope.
+
+Exit outcomes:
+
+- The V1 registry is backed by SQLite.
+- The registry stores teams, products, product versions, metadata, and lineage dependencies.
+- SQL query behavior lives in repository modules or database modules.
+- Service workflows map repository failures into domain-level errors.
+- Registry initialization is tested.
+- The system remains scoped to one cluster and one POSIX-like filesystem for V1.
+
+## 11. Provide Auditability for Critical Actions
+
+Feather Mesh must record enough operational history to support governance and troubleshooting.
+
+Exit outcomes:
+
+- Publish, read/show, metadata mutation, and consume actions produce audit records or equivalent structured logs.
+- Audit records include actor, action, target product/version where applicable, timestamp, and outcome.
+- Metadata policy fields are visible during publication and inspection.
+- Governance operators can identify who published or consumed a product version.
+- Audit behavior is covered by tests or a documented manual verification flow.
+
+## 12. Deliver Stable Operational Behavior
+
+Feather Mesh must be reliable enough for repeatable HPC workflows.
+
+Exit outcomes:
+
+- Catalog operations are idempotent where reasonable.
+- Managed-copy failures distinguish missing product, missing version, missing source, permission failure, and existing destination.
+- CLI failures are stable and actionable enough for scripts.
+- Retrieval either completes successfully or leaves clear state for retry.
+- `cargo test` passes from `feather-mesh/` at project exit, or any failures are documented with accepted rationale.
+
+## 13. Demonstrate End-to-End V1 Workflow
+
+Feather Mesh must demonstrate the full producer-to-consumer loop.
+
+Exit outcomes:
+
+- A producer can publish a valid product with required metadata.
+- A consumer can discover that product with search.
+- A consumer can inspect the product and its version metadata.
+- A consumer can inspect lineage for the selected version.
+- A consumer can consume a pinned version into a local output path.
+- The workflow is reproducible from documented commands in the repository.
+
+## 14. Document Scope, Non-Goals, and Contributor Guidance
+
+Feather Mesh must leave the project in a state that future contributors can continue without rediscovering product decisions.
+
+Exit outcomes:
+
+- The README identifies the CLI crate, core crate, product definition document, and test command.
+- Architecture documentation explains the split between `mesh_cli`, `mesh_core::services`, and repositories.
+- The V1 boundaries are documented:
+  - single cluster,
+  - single filesystem,
+  - SQLite-backed local registry,
+  - managed-copy default consumption,
+  - metadata-driven search only,
+  - filesystem-native access enforcement.
+- Non-goals are documented, including no universal data lake, no scheduler replacement, no semantic retrieval in V1, and no replacement for filesystem access control.
+
+## 15. Define Success Signals for Project Review
+
+Feather Mesh must provide measurable signals that the V1 satisfies the PDD's intended value.
+
+Exit outcomes:
+
+- At least one fixture or demo workflow shows product publication volume greater than zero.
+- At least one cross-team-style discovery and consumption scenario is demonstrated with separate producer and consumer roles or fixtures.
+- Keystone metadata completeness is measurable across registered products.
+- Pinned version consumption is demonstrated.
+- Retrieval failures can be categorized by cause class.
+- The project can explain how V1 reduces reliance on ad hoc paths, stale wiki documentation, and producer-to-consumer manual handoff.
+

--- a/feather-mesh/Cargo.lock
+++ b/feather-mesh/Cargo.lock
@@ -3,12 +3,86 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -22,6 +96,17 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
+]
 
 [[package]]
 name = "bumpalo"
@@ -60,10 +145,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "fallible-iterator"
@@ -78,16 +225,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
 
 [[package]]
 name = "hashbrown"
@@ -106,6 +279,12 @@ checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
  "hashbrown",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "iana-time-zone"
@@ -130,6 +309,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -165,6 +350,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,7 +371,14 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 name = "mesh_cli"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
+ "chrono",
+ "clap",
  "mesh_core",
+ "predicates",
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -191,7 +389,14 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "thiserror",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-traits"
@@ -209,10 +414,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -231,6 +472,41 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rsqlite-vfs"
@@ -255,6 +531,19 @@ dependencies = [
  "libsqlite3-sys",
  "smallvec",
  "sqlite-wasm-rs",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -331,6 +620,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +635,25 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -368,10 +682,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -473,6 +802,15 @@ name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]

--- a/feather-mesh/Cargo.toml
+++ b/feather-mesh/Cargo.toml
@@ -4,3 +4,15 @@ members = [
   "mesh_core"
 ]
 resolver = "2"
+
+[workspace.dependencies]
+chrono = { version = "0.4.44", features = ["serde"] }
+clap = { version = "4.5.53", features = ["derive"] }
+rusqlite = { version = "0.39.0", features = ["bundled"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+thiserror = "2.0.17"
+
+assert_cmd = "2.1.1"
+predicates = "3.1.3"
+tempfile = "3.23.0"

--- a/feather-mesh/README.md
+++ b/feather-mesh/README.md
@@ -88,27 +88,69 @@ target/release/mesh_cli
 
 ---
 
-## Run the Project
+## Run the CLI
 
-### Run in Debug Mode
-
-```bash
-cargo run
-```
-
-### Run in Release Mode
-
-```bash
-cargo run --release
-```
-
-### Run With Arguments
+The package is still named `mesh_cli`, but the command help and user-facing surface are `feam`.
 
 ```bash
 cargo run -p mesh_cli -- --help
 ```
 
-(Note the `--` before arguments.)
+Use `--registry <path>` to select a SQLite registry. If omitted, the CLI uses `registry.db` in the current directory.
+
+### Core Workflow
+
+```bash
+cargo run -p mesh_cli -- --registry /tmp/feam.db init
+
+cargo run -p mesh_cli -- --registry /tmp/feam.db serve ./data.csv \
+  --name "Daily Observations" \
+  --asset-type file \
+  --version v1.0.0 \
+  --owner-team Climate \
+  --producer "Climate Lab" \
+  --usage-policy "Internal research use" \
+  --data-quality production \
+  --classification internal
+
+cargo run -p mesh_cli -- --registry /tmp/feam.db search daily
+cargo run -p mesh_cli -- --registry /tmp/feam.db --format json show 1
+cargo run -p mesh_cli -- --registry /tmp/feam.db lineage 1
+cargo run -p mesh_cli -- --registry /tmp/feam.db consume 1 --version v1.0.0 --out ./copy.csv
+```
+
+### Commands
+
+The implemented command surface is:
+
+- `init`
+- `serve`
+- `search`
+- `show`
+- `consume`
+- `lineage`
+- `validate-metadata`
+- `teams`
+- `products`
+
+Global options:
+
+- `--registry <path>`
+- `--format <table|json>`
+- `--verbose`
+- `--help`
+- `--version`
+
+### Exit Codes
+
+| Code | Meaning |
+| ---- | ------- |
+| `0` | success |
+| `1` | general runtime error |
+| `2` | invalid CLI usage |
+| `3` | validation failure |
+| `4` | not found |
+| `5` | permission or policy failure |
 
 ---
 

--- a/feather-mesh/mesh_cli/Cargo.toml
+++ b/feather-mesh/mesh_cli/Cargo.toml
@@ -5,3 +5,12 @@ edition = "2024"
 
 [dependencies]
 mesh_core = { path = "../mesh_core" }
+chrono = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+assert_cmd = { workspace = true }
+predicates = { workspace = true }
+tempfile = { workspace = true }

--- a/feather-mesh/mesh_cli/src/main.rs
+++ b/feather-mesh/mesh_cli/src/main.rs
@@ -275,7 +275,7 @@ fn parse_lineage(values: Vec<String>) -> Result<Vec<LineageReference>, RegistryE
 }
 
 fn read_metadata(path: PathBuf) -> Result<ServeRequest, RegistryError> {
-    let contents = fs::read_to_string(path)?;
+    let contents = fs::read_to_string(path).map_err(map_io_error)?;
     serde_json::from_str(&contents).map_err(RegistryError::from)
 }
 
@@ -434,10 +434,19 @@ fn print_json<T: Serialize + ?Sized>(value: &T) -> Result<(), RegistryError> {
 }
 
 fn truncate(value: &str, width: usize) -> String {
-    if value.len() <= width {
+    if value.chars().count() <= width {
         value.to_string()
     } else {
-        format!("{}...", &value[..width.saturating_sub(3)])
+        let truncated: String = value.chars().take(width.saturating_sub(3)).collect();
+        format!("{truncated}...")
+    }
+}
+
+fn map_io_error(err: std::io::Error) -> RegistryError {
+    if err.kind() == std::io::ErrorKind::PermissionDenied {
+        RegistryError::Permission(err.to_string())
+    } else {
+        RegistryError::Filesystem(err)
     }
 }
 

--- a/feather-mesh/mesh_cli/src/main.rs
+++ b/feather-mesh/mesh_cli/src/main.rs
@@ -1,17 +1,506 @@
-const HELP: &str = "\
-Feather Mesh CLI
+use std::fmt;
+use std::fs;
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::str::FromStr;
 
-Usage:
-  mesh_cli [--help]
+use clap::{Parser, Subcommand, ValueEnum};
+use mesh_core::domain::{AssetType, Classification, DataQuality, RegistryError};
+use mesh_core::services::{
+    ConsumeRequest, InitResponse, LineageReference, RegistryService, SearchRequest, ServeRequest,
+};
+use mesh_core::{DEFAULT_DB_FILENAME, init_db};
+use serde::Serialize;
 
-Status:
-  CLI command parsing and terminal UX live in mesh_cli.
-  Business workflows live in mesh_core::services.
+#[derive(Debug, Parser)]
+#[command(name = "feam", version, about = "Feather Mesh CLI")]
+struct Cli {
+    #[arg(long, global = true, value_name = "PATH", default_value = DEFAULT_DB_FILENAME)]
+    registry: PathBuf,
+    #[arg(long, global = true, value_enum, default_value_t = OutputFormat::Table)]
+    format: OutputFormat,
+    #[arg(long, global = true)]
+    verbose: bool,
+    #[command(subcommand)]
+    command: Command,
+}
 
-Next implementation work should replace this guidance with concrete commands that
-call mesh_core services for publishing, discovering, and retrieving data products.
-";
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum OutputFormat {
+    Table,
+    Json,
+}
 
-fn main() {
-    println!("{HELP}");
+#[derive(Debug, Subcommand)]
+enum Command {
+    Init,
+    Serve {
+        path: PathBuf,
+        #[arg(long)]
+        name: String,
+        #[arg(long, value_enum)]
+        asset_type: CliAssetType,
+        #[arg(long)]
+        version: String,
+        #[arg(long)]
+        owner_team: String,
+        #[arg(long)]
+        producer: String,
+        #[arg(long)]
+        usage_policy: String,
+        #[arg(long, value_enum)]
+        data_quality: CliDataQuality,
+        #[arg(long, value_enum)]
+        classification: CliClassification,
+        #[arg(long)]
+        description: Option<String>,
+        #[arg(long)]
+        intended_use: Option<String>,
+        #[arg(long = "lineage")]
+        lineage: Vec<String>,
+    },
+    Search {
+        query: Option<String>,
+        #[arg(long, value_enum)]
+        asset_type: Option<CliAssetType>,
+        #[arg(long, value_enum)]
+        data_quality: Option<CliDataQuality>,
+        #[arg(long, value_enum)]
+        classification: Option<CliClassification>,
+        #[arg(long)]
+        owner_team: Option<String>,
+    },
+    Show {
+        product_id_or_source_path: String,
+        #[arg(long)]
+        version: Option<String>,
+    },
+    Consume {
+        product_id_or_source_path: String,
+        #[arg(long)]
+        version: String,
+        #[arg(long)]
+        out: PathBuf,
+        #[arg(long)]
+        overwrite: bool,
+    },
+    Lineage {
+        product_id_or_source_path: String,
+        #[arg(long)]
+        version: Option<String>,
+    },
+    ValidateMetadata {
+        metadata_file: PathBuf,
+    },
+    Teams,
+    Products,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+#[value(rename_all = "snake_case")]
+enum CliAssetType {
+    File,
+    Directory,
+    Dataset,
+    Table,
+    ModelArtifact,
+    ReportArtifact,
+    ManifestCollection,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum CliDataQuality {
+    Production,
+    Qualified,
+    Unverified,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum CliClassification {
+    Public,
+    Internal,
+    Restricted,
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("{err}");
+            ExitCode::from(exit_code(&err))
+        }
+    }
+}
+
+fn run() -> Result<(), RegistryError> {
+    let cli = Cli::parse();
+
+    if matches!(cli.command, Command::Init) {
+        init_db(&cli.registry)?;
+        let response = InitResponse {
+            registry_path: cli.registry.to_string_lossy().into_owned(),
+            status: "initialized".to_string(),
+        };
+        return print_init(&response, cli.format);
+    }
+
+    let conn = init_db(&cli.registry)?;
+    let service = RegistryService::new(&conn);
+    match cli.command {
+        Command::Init => unreachable!(),
+        Command::Serve {
+            path,
+            name,
+            asset_type,
+            version,
+            owner_team,
+            producer,
+            usage_policy,
+            data_quality,
+            classification,
+            description,
+            intended_use,
+            lineage,
+        } => {
+            let request = ServeRequest {
+                source_path: path,
+                name,
+                asset_type: asset_type.into(),
+                version,
+                owner_team,
+                producer,
+                usage_policy,
+                data_quality: data_quality.into(),
+                classification: classification.into(),
+                description,
+                intended_use,
+                lineage: parse_lineage(lineage)?,
+            };
+            let response = service.serve(request)?;
+            print_serve(&response, cli.format)
+        }
+        Command::Search {
+            query,
+            asset_type,
+            data_quality,
+            classification,
+            owner_team,
+        } => {
+            let products = service.search_products(SearchRequest {
+                query,
+                asset_type: asset_type.map(Into::into),
+                data_quality: data_quality.map(Into::into),
+                classification: classification.map(Into::into),
+                owner_team,
+            })?;
+            print_products(&products, cli.format)
+        }
+        Command::Show {
+            product_id_or_source_path,
+            version,
+        } => {
+            let detail = service.show_product(&product_id_or_source_path, version.as_deref())?;
+            print_show(&detail, cli.format)
+        }
+        Command::Consume {
+            product_id_or_source_path,
+            version,
+            out,
+            overwrite,
+        } => {
+            let receipt = service.consume(ConsumeRequest {
+                product_ref: product_id_or_source_path,
+                version,
+                out,
+                overwrite,
+            })?;
+            print_consume(&receipt, cli.format)
+        }
+        Command::Lineage {
+            product_id_or_source_path,
+            version,
+        } => {
+            let lineage = service.lineage(&product_id_or_source_path, version.as_deref())?;
+            print_lineage(&lineage, cli.format)
+        }
+        Command::ValidateMetadata { metadata_file } => {
+            let request = read_metadata(metadata_file)?;
+            service.validate_serve_request(&request)?;
+            match cli.format {
+                OutputFormat::Json => print_json(&serde_json::json!({"status": "valid"})),
+                OutputFormat::Table => {
+                    println!("Metadata valid");
+                    Ok(())
+                }
+            }
+        }
+        Command::Teams => {
+            let teams = service.list_teams()?;
+            match cli.format {
+                OutputFormat::Json => print_json(&teams),
+                OutputFormat::Table => {
+                    if teams.is_empty() {
+                        println!("No teams registered");
+                    } else {
+                        println!("{:<8}  {:<24}  CREATED_AT", "TEAM_ID", "NAME");
+                        for team in teams {
+                            println!(
+                                "{:<8}  {:<24}  {}",
+                                team.team_id, team.name, team.created_at
+                            );
+                        }
+                    }
+                    Ok(())
+                }
+            }
+        }
+        Command::Products => {
+            let products = service.list_products()?;
+            print_products(&products, cli.format)
+        }
+    }
+}
+
+fn parse_lineage(values: Vec<String>) -> Result<Vec<LineageReference>, RegistryError> {
+    values
+        .into_iter()
+        .map(|value| {
+            let (source, version) = value
+                .rsplit_once('@')
+                .map(|(source, version)| (source.to_string(), Some(version.to_string())))
+                .unwrap_or((value, None));
+            Ok(LineageReference { source, version })
+        })
+        .collect()
+}
+
+fn read_metadata(path: PathBuf) -> Result<ServeRequest, RegistryError> {
+    let contents = fs::read_to_string(path)?;
+    serde_json::from_str(&contents).map_err(RegistryError::from)
+}
+
+fn print_init(response: &InitResponse, format: OutputFormat) -> Result<(), RegistryError> {
+    match format {
+        OutputFormat::Json => print_json(response),
+        OutputFormat::Table => {
+            println!("Registry initialized: {}", response.registry_path);
+            Ok(())
+        }
+    }
+}
+
+fn print_serve(
+    response: &mesh_core::services::ServeResponse,
+    format: OutputFormat,
+) -> Result<(), RegistryError> {
+    match format {
+        OutputFormat::Json => print_json(response),
+        OutputFormat::Table => {
+            println!("Published {}", response.name);
+            println!("product_id: {}", response.product_id);
+            println!("version_id: {}", response.version_id);
+            println!("version: {}", response.version);
+            println!("source_reference: {}", response.source_reference);
+            println!("status: {}", response.status);
+            Ok(())
+        }
+    }
+}
+
+fn print_products(
+    products: &[mesh_core::services::ProductSummary],
+    format: OutputFormat,
+) -> Result<(), RegistryError> {
+    match format {
+        OutputFormat::Json => print_json(products),
+        OutputFormat::Table => {
+            if products.is_empty() {
+                println!("No products found");
+            } else {
+                println!(
+                    "{:<10}  {:<24}  {:<18}  {:<18}  {:<10}  {:<12}  SOURCE",
+                    "PRODUCT_ID", "NAME", "OWNER_TEAM", "PRODUCER", "VERSION", "QUALITY"
+                );
+                for product in products {
+                    println!(
+                        "{:<10}  {:<24}  {:<18}  {:<18}  {:<10}  {:<12}  {}",
+                        product.product_id,
+                        truncate(&product.name, 24),
+                        truncate(&product.owner_team, 18),
+                        truncate(&product.producer, 18),
+                        product.version.as_deref().unwrap_or("-"),
+                        product.data_quality.as_deref().unwrap_or("-"),
+                        product.source_reference.as_deref().unwrap_or("-"),
+                    );
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+fn print_show(
+    detail: &mesh_core::services::ProductDetail,
+    format: OutputFormat,
+) -> Result<(), RegistryError> {
+    match format {
+        OutputFormat::Json => print_json(detail),
+        OutputFormat::Table => {
+            println!("product_id: {}", detail.product_id);
+            println!("name: {}", detail.name);
+            println!("owner_team: {}", detail.owner_team);
+            println!("producer: {}", detail.producer);
+            println!("usage_policy: {}", detail.usage_policy);
+            if let Some(description) = &detail.description {
+                println!("description: {description}");
+            }
+            if let Some(intended_use) = &detail.intended_use {
+                println!("intended_use: {intended_use}");
+            }
+            println!("created_at: {}", detail.created_at);
+            println!("version: {}", detail.selected_version.version);
+            println!("version_id: {}", detail.selected_version.version_id);
+            println!("asset_type: {}", detail.selected_version.asset_type);
+            println!("data_quality: {}", detail.selected_version.data_quality);
+            println!("classification: {}", detail.selected_version.classification);
+            println!(
+                "source_reference: {}",
+                detail.selected_version.source_reference
+            );
+            println!("lineage_status: {}", detail.lineage.status);
+            println!(
+                "lineage_dependencies: {}",
+                detail.lineage.dependencies.len()
+            );
+            Ok(())
+        }
+    }
+}
+
+fn print_lineage(
+    lineage: &mesh_core::services::LineageResponse,
+    format: OutputFormat,
+) -> Result<(), RegistryError> {
+    match format {
+        OutputFormat::Json => print_json(lineage),
+        OutputFormat::Table => {
+            println!("product_id: {}", lineage.product_id);
+            println!("version: {}", lineage.version);
+            println!("status: {}", lineage.status);
+            if lineage.dependencies.is_empty() {
+                println!("No upstream dependencies recorded");
+            } else {
+                println!(
+                    "{:<32}  {:<12}  {:<10}  PRODUCER",
+                    "UPSTREAM_SOURCE", "VERSION", "PRODUCT_ID"
+                );
+                for dep in &lineage.dependencies {
+                    println!(
+                        "{:<32}  {:<12}  {:<10}  {}",
+                        truncate(&dep.upstream_source_reference, 32),
+                        dep.upstream_version.as_deref().unwrap_or("-"),
+                        dep.upstream_product_id
+                            .map(|id| id.to_string())
+                            .unwrap_or_else(|| "-".to_string()),
+                        dep.upstream_producer.as_deref().unwrap_or("-"),
+                    );
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+fn print_consume(
+    receipt: &mesh_core::services::ConsumeReceipt,
+    format: OutputFormat,
+) -> Result<(), RegistryError> {
+    match format {
+        OutputFormat::Json => print_json(receipt),
+        OutputFormat::Table => {
+            println!("Consumed product {}", receipt.product_id);
+            println!("version: {}", receipt.version);
+            println!("source_reference: {}", receipt.source_reference);
+            println!("output_path: {}", receipt.output_path);
+            println!("retrieved_at: {}", receipt.retrieved_at);
+            Ok(())
+        }
+    }
+}
+
+fn print_json<T: Serialize + ?Sized>(value: &T) -> Result<(), RegistryError> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+fn truncate(value: &str, width: usize) -> String {
+    if value.len() <= width {
+        value.to_string()
+    } else {
+        format!("{}...", &value[..width.saturating_sub(3)])
+    }
+}
+
+fn exit_code(err: &RegistryError) -> u8 {
+    match err {
+        RegistryError::Validation(_) => 3,
+        RegistryError::NotFound(_) | RegistryError::SourceMissing(_) => 4,
+        RegistryError::Permission(_) | RegistryError::DestinationExists(_) => 5,
+        RegistryError::Database(_)
+        | RegistryError::Filesystem(_)
+        | RegistryError::Serialization(_) => 1,
+    }
+}
+
+impl From<CliAssetType> for AssetType {
+    fn from(value: CliAssetType) -> Self {
+        AssetType::from_str(&value.to_string()).expect("clap enum values match core asset types")
+    }
+}
+
+impl From<CliDataQuality> for DataQuality {
+    fn from(value: CliDataQuality) -> Self {
+        DataQuality::from_str(&value.to_string()).expect("clap enum values match core qualities")
+    }
+}
+
+impl From<CliClassification> for Classification {
+    fn from(value: CliClassification) -> Self {
+        Classification::from_str(&value.to_string())
+            .expect("clap enum values match core classifications")
+    }
+}
+
+impl fmt::Display for CliAssetType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::File => "file",
+            Self::Directory => "directory",
+            Self::Dataset => "dataset",
+            Self::Table => "table",
+            Self::ModelArtifact => "model_artifact",
+            Self::ReportArtifact => "report_artifact",
+            Self::ManifestCollection => "manifest_collection",
+        })
+    }
+}
+
+impl fmt::Display for CliDataQuality {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Production => "production",
+            Self::Qualified => "qualified",
+            Self::Unverified => "unverified",
+        })
+    }
+}
+
+impl fmt::Display for CliClassification {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Public => "public",
+            Self::Internal => "internal",
+            Self::Restricted => "restricted",
+        })
+    }
 }

--- a/feather-mesh/mesh_cli/tests/cli_workflow_tests.rs
+++ b/feather-mesh/mesh_cli/tests/cli_workflow_tests.rs
@@ -1,0 +1,225 @@
+use std::fs;
+use std::path::Path;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn feam() -> Command {
+    Command::cargo_bin("mesh_cli").expect("binary exists")
+}
+
+fn registry_arg(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+#[test]
+fn help_shows_canonical_commands() {
+    feam()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("serve"))
+        .stdout(predicate::str::contains("consume"))
+        .stdout(predicate::str::contains("validate-metadata"));
+}
+
+#[test]
+fn primary_demo_workflow_works_with_json_outputs_and_receipt() {
+    let temp = tempdir().unwrap();
+    let registry = temp.path().join("registry.db");
+    let source = temp.path().join("daily.csv");
+    let out = temp.path().join("copy.csv");
+    fs::write(&source, "date,value\n2026-07-05,42\n").unwrap();
+
+    feam()
+        .args(["--registry", &registry_arg(&registry), "init"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Registry initialized"));
+
+    feam()
+        .args([
+            "--registry",
+            &registry_arg(&registry),
+            "serve",
+            &registry_arg(&source),
+            "--name",
+            "Daily Observations",
+            "--asset-type",
+            "file",
+            "--version",
+            "v1.0.0",
+            "--owner-team",
+            "Climate",
+            "--producer",
+            "Climate Lab",
+            "--usage-policy",
+            "Internal research use",
+            "--data-quality",
+            "production",
+            "--classification",
+            "internal",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("product_id: 1"));
+
+    let search = feam()
+        .args([
+            "--registry",
+            &registry_arg(&registry),
+            "--format",
+            "json",
+            "search",
+            "daily",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let search_json: Value = serde_json::from_slice(&search).unwrap();
+    assert_eq!(search_json[0]["name"], "Daily Observations");
+
+    let show = feam()
+        .args([
+            "--registry",
+            &registry_arg(&registry),
+            "--format",
+            "json",
+            "show",
+            "1",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let show_json: Value = serde_json::from_slice(&show).unwrap();
+    assert_eq!(show_json["selected_version"]["version"], "v1.0.0");
+
+    let lineage = feam()
+        .args([
+            "--registry",
+            &registry_arg(&registry),
+            "--format",
+            "json",
+            "lineage",
+            "1",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let lineage_json: Value = serde_json::from_slice(&lineage).unwrap();
+    assert_eq!(lineage_json["status"], "no_lineage");
+
+    feam()
+        .args([
+            "--registry",
+            &registry_arg(&registry),
+            "consume",
+            "1",
+            "--version",
+            "v1.0.0",
+            "--out",
+            &registry_arg(&out),
+        ])
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(&out).unwrap(),
+        "date,value\n2026-07-05,42\n"
+    );
+    let receipt = out.with_file_name("copy.csv.feam-receipt.json");
+    let receipt_json: Value = serde_json::from_str(&fs::read_to_string(receipt).unwrap()).unwrap();
+    assert_eq!(receipt_json["product_id"], 1);
+    assert!(receipt_json["checksum"].is_null());
+}
+
+#[test]
+fn validation_not_found_and_policy_exit_codes_are_stable() {
+    let temp = tempdir().unwrap();
+    let registry = temp.path().join("registry.db");
+    let source = temp.path().join("daily.csv");
+    let out = temp.path().join("copy.csv");
+    fs::write(&source, "x\n").unwrap();
+    fs::write(&out, "existing\n").unwrap();
+
+    feam()
+        .args([
+            "--registry",
+            &registry_arg(&registry),
+            "serve",
+            &registry_arg(&source),
+            "--name",
+            "Bad/Name",
+            "--asset-type",
+            "file",
+            "--version",
+            "v1",
+            "--owner-team",
+            "Climate",
+            "--producer",
+            "Climate Lab",
+            "--usage-policy",
+            "Internal",
+            "--data-quality",
+            "production",
+            "--classification",
+            "internal",
+        ])
+        .assert()
+        .code(3)
+        .stderr(predicate::str::contains("name"));
+
+    feam()
+        .args(["--registry", &registry_arg(&registry), "show", "999"])
+        .assert()
+        .code(4);
+
+    feam()
+        .args([
+            "--registry",
+            &registry_arg(&registry),
+            "serve",
+            &registry_arg(&source),
+            "--name",
+            "Daily",
+            "--asset-type",
+            "file",
+            "--version",
+            "v1",
+            "--owner-team",
+            "Climate",
+            "--producer",
+            "Climate Lab",
+            "--usage-policy",
+            "Internal",
+            "--data-quality",
+            "production",
+            "--classification",
+            "internal",
+        ])
+        .assert()
+        .success();
+
+    feam()
+        .args([
+            "--registry",
+            &registry_arg(&registry),
+            "consume",
+            "1",
+            "--version",
+            "v1",
+            "--out",
+            &registry_arg(&out),
+        ])
+        .assert()
+        .code(5)
+        .stderr(predicate::str::contains("destination exists"));
+}

--- a/feather-mesh/mesh_cli/tests/cli_workflow_tests.rs
+++ b/feather-mesh/mesh_cli/tests/cli_workflow_tests.rs
@@ -223,3 +223,43 @@ fn validation_not_found_and_policy_exit_codes_are_stable() {
         .code(5)
         .stderr(predicate::str::contains("destination exists"));
 }
+
+#[test]
+fn table_output_handles_multibyte_text_when_truncating() {
+    let temp = tempdir().unwrap();
+    let registry = temp.path().join("registry.db");
+    let source = temp.path().join("daily.csv");
+    fs::write(&source, "x\n").unwrap();
+
+    feam()
+        .args([
+            "--registry",
+            &registry_arg(&registry),
+            "serve",
+            &registry_arg(&source),
+            "--name",
+            "Daily",
+            "--asset-type",
+            "file",
+            "--version",
+            "v1",
+            "--owner-team",
+            "Equipe Meteo",
+            "--producer",
+            "éééééééééééééééééééé",
+            "--usage-policy",
+            "Internal",
+            "--data-quality",
+            "production",
+            "--classification",
+            "internal",
+        ])
+        .assert()
+        .success();
+
+    feam()
+        .args(["--registry", &registry_arg(&registry), "products"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ééé"));
+}

--- a/feather-mesh/mesh_core/Cargo.toml
+++ b/feather-mesh/mesh_core/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-chrono = { version = "0.4.44", features = ["serde"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-rusqlite = { version = "0.39.0", features = ["bundled"] }
+chrono = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+rusqlite = { workspace = true }
+thiserror = { workspace = true }

--- a/feather-mesh/mesh_core/src/db.rs
+++ b/feather-mesh/mesh_core/src/db.rs
@@ -83,6 +83,10 @@ pub(crate) fn init_schema(conn: &Connection) -> Result<()> {
         CREATE INDEX IF NOT EXISTS idx_data_products_owner_team_id ON data_products(owner_team_id);
         CREATE INDEX IF NOT EXISTS idx_data_product_versions_data_product_id ON data_product_versions(data_product_id);
         CREATE INDEX IF NOT EXISTS idx_data_product_versions_source_path ON data_product_versions(source_path);
+        CREATE UNIQUE INDEX IF NOT EXISTS ux_data_product_versions_product_label
+            ON data_product_versions(data_product_id, version_label);
+        CREATE UNIQUE INDEX IF NOT EXISTS ux_data_product_versions_source_path
+            ON data_product_versions(source_path);
         CREATE INDEX IF NOT EXISTS idx_metadata_data_product_version_id ON metadata(data_product_version_id);
         CREATE INDEX IF NOT EXISTS idx_lineage_dependencies_downstream_version_id ON lineage_dependencies(downstream_version_id);
         "#,
@@ -99,6 +103,18 @@ pub(crate) fn init_schema(conn: &Connection) -> Result<()> {
         "data_products",
         "usage_policy",
         "TEXT NOT NULL DEFAULT 'unspecified'",
+    )?;
+    add_column_if_missing(
+        conn,
+        "data_product_versions",
+        "classification",
+        "TEXT NOT NULL DEFAULT 'internal'",
+    )?;
+    conn.execute(
+        "UPDATE data_product_versions
+         SET classification = 'internal'
+         WHERE classification IS NULL",
+        [],
     )?;
 
     Ok(())
@@ -134,14 +150,14 @@ mod tests {
 
     static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-    fn unique_test_db_path() -> PathBuf {
+    fn unique_test_db_path(prefix: &str) -> PathBuf {
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("System time before UNIX EPOCH")
             .as_nanos();
         let mut path = std::env::temp_dir();
         path.push(format!(
-            "mesh_core_registry_{}_{}_{}.db",
+            "{prefix}_{}_{}_{}.db",
             std::process::id(),
             timestamp,
             DB_COUNTER.fetch_add(1, Ordering::Relaxed)
@@ -151,7 +167,7 @@ mod tests {
 
     #[test]
     fn init_db_creates_registry_db_and_enables_wal() {
-        let path = unique_test_db_path();
+        let path = unique_test_db_path("mesh_core_registry");
         if path.exists() {
             fs::remove_file(&path).unwrap();
         }
@@ -179,13 +195,108 @@ mod tests {
 
     #[test]
     fn init_db_is_idempotent() {
-        let path = unique_test_db_path();
+        let path = unique_test_db_path("mesh_core_registry");
         if path.exists() {
             fs::remove_file(&path).unwrap();
         }
 
         init_db(&path).expect("First init should succeed");
         init_db(&path).expect("Second init should still succeed");
+
+        fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn init_db_backfills_legacy_classification_and_adds_unique_indexes() {
+        let path = unique_test_db_path("mesh_core_registry");
+        if path.exists() {
+            fs::remove_file(&path).unwrap();
+        }
+
+        {
+            let conn = Connection::open(&path).expect("Failed to create legacy database");
+            conn.execute_batch(
+                r#"
+                CREATE TABLE teams (
+                    team_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL UNIQUE,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+                CREATE TABLE data_products (
+                    product_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    description TEXT,
+                    owner_team_id INTEGER NOT NULL,
+                    producer TEXT NOT NULL,
+                    usage_policy TEXT NOT NULL,
+                    intended_use TEXT,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    FOREIGN KEY(owner_team_id) REFERENCES teams(team_id) ON DELETE CASCADE
+                );
+                CREATE TABLE data_product_versions (
+                    version_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    data_product_id INTEGER NOT NULL,
+                    version_label TEXT NOT NULL,
+                    asset_type TEXT NOT NULL,
+                    source_path TEXT NOT NULL,
+                    data_quality TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    FOREIGN KEY(data_product_id) REFERENCES data_products(product_id) ON DELETE CASCADE
+                );
+                CREATE TABLE metadata (
+                    metadata_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    data_product_version_id INTEGER NOT NULL,
+                    namespace TEXT,
+                    meta_key TEXT NOT NULL,
+                    meta_value TEXT,
+                    value_type TEXT,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    FOREIGN KEY(data_product_version_id) REFERENCES data_product_versions(version_id) ON DELETE CASCADE
+                );
+                CREATE TABLE lineage_dependencies (
+                    dependency_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    downstream_version_id INTEGER NOT NULL,
+                    upstream_product_uri TEXT NOT NULL,
+                    upstream_version TEXT,
+                    FOREIGN KEY(downstream_version_id) REFERENCES data_product_versions(version_id) ON DELETE CASCADE
+                );
+                INSERT INTO teams (name) VALUES ('Legacy');
+                INSERT INTO data_products
+                    (name, owner_team_id, producer, usage_policy)
+                    VALUES ('Legacy Product', 1, 'Legacy Producer', 'Internal');
+                INSERT INTO data_product_versions
+                    (data_product_id, version_label, asset_type, source_path, data_quality)
+                    VALUES (1, 'v1', 'file', '/legacy/source.csv', 'production');
+                "#,
+            )
+            .expect("Failed to seed legacy schema");
+        }
+
+        let conn = init_db(&path).expect("Failed to migrate legacy database");
+        let classification: String = conn
+            .query_row(
+                "SELECT classification FROM data_product_versions WHERE version_id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("Failed to read backfilled classification");
+        assert_eq!(classification, "internal");
+
+        let duplicate_label = conn.execute(
+            "INSERT INTO data_product_versions
+                (data_product_id, version_label, asset_type, source_path, data_quality, classification)
+             VALUES (1, 'v1', 'file', '/legacy/other.csv', 'production', 'internal')",
+            [],
+        );
+        assert!(duplicate_label.is_err());
+
+        let duplicate_source = conn.execute(
+            "INSERT INTO data_product_versions
+                (data_product_id, version_label, asset_type, source_path, data_quality, classification)
+             VALUES (1, 'v2', 'file', '/legacy/source.csv', 'production', 'internal')",
+            [],
+        );
+        assert!(duplicate_source.is_err());
 
         fs::remove_file(&path).ok();
     }

--- a/feather-mesh/mesh_core/src/db.rs
+++ b/feather-mesh/mesh_core/src/db.rs
@@ -42,6 +42,8 @@ pub(crate) fn init_schema(conn: &Connection) -> Result<()> {
             name TEXT NOT NULL,
             description TEXT,
             owner_team_id INTEGER NOT NULL,
+            producer TEXT NOT NULL,
+            usage_policy TEXT NOT NULL,
             intended_use TEXT,
             created_at TEXT NOT NULL DEFAULT (datetime('now')),
             FOREIGN KEY(owner_team_id) REFERENCES teams(team_id) ON DELETE CASCADE
@@ -54,7 +56,7 @@ pub(crate) fn init_schema(conn: &Connection) -> Result<()> {
             asset_type TEXT NOT NULL,
             source_path TEXT NOT NULL,
             data_quality TEXT NOT NULL,
-            classification TEXT,
+            classification TEXT NOT NULL,
             created_at TEXT NOT NULL DEFAULT (datetime('now')),
             FOREIGN KEY(data_product_id) REFERENCES data_products(product_id) ON DELETE CASCADE
         );
@@ -80,11 +82,45 @@ pub(crate) fn init_schema(conn: &Connection) -> Result<()> {
 
         CREATE INDEX IF NOT EXISTS idx_data_products_owner_team_id ON data_products(owner_team_id);
         CREATE INDEX IF NOT EXISTS idx_data_product_versions_data_product_id ON data_product_versions(data_product_id);
+        CREATE INDEX IF NOT EXISTS idx_data_product_versions_source_path ON data_product_versions(source_path);
         CREATE INDEX IF NOT EXISTS idx_metadata_data_product_version_id ON metadata(data_product_version_id);
         CREATE INDEX IF NOT EXISTS idx_lineage_dependencies_downstream_version_id ON lineage_dependencies(downstream_version_id);
         "#,
     )?;
 
+    add_column_if_missing(
+        conn,
+        "data_products",
+        "producer",
+        "TEXT NOT NULL DEFAULT 'unknown'",
+    )?;
+    add_column_if_missing(
+        conn,
+        "data_products",
+        "usage_policy",
+        "TEXT NOT NULL DEFAULT 'unspecified'",
+    )?;
+
+    Ok(())
+}
+
+fn add_column_if_missing(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    definition: &str,
+) -> Result<()> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
+    for row in rows {
+        if row? == column {
+            return Ok(());
+        }
+    }
+    conn.execute(
+        &format!("ALTER TABLE {table} ADD COLUMN {column} {definition}"),
+        [],
+    )?;
     Ok(())
 }
 
@@ -93,7 +129,10 @@ mod tests {
     use super::*;
     use std::fs;
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     fn unique_test_db_path() -> PathBuf {
         let timestamp = SystemTime::now()
@@ -101,7 +140,12 @@ mod tests {
             .expect("System time before UNIX EPOCH")
             .as_nanos();
         let mut path = std::env::temp_dir();
-        path.push(format!("mesh_core_registry_{}.db", timestamp));
+        path.push(format!(
+            "mesh_core_registry_{}_{}_{}.db",
+            std::process::id(),
+            timestamp,
+            DB_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
         path
     }
 

--- a/feather-mesh/mesh_core/src/domain.rs
+++ b/feather-mesh/mesh_core/src/domain.rs
@@ -1,0 +1,228 @@
+use std::fmt;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum RegistryError {
+    #[error("validation failed: {0}")]
+    Validation(#[from] ValidationError),
+    #[error("not found: {0}")]
+    NotFound(String),
+    #[error("permission or policy failure: {0}")]
+    Permission(String),
+    #[error("source missing: {0}")]
+    SourceMissing(String),
+    #[error("destination exists: {0}")]
+    DestinationExists(String),
+    #[error("database error: {0}")]
+    Database(#[from] rusqlite::Error),
+    #[error("filesystem error: {0}")]
+    Filesystem(#[from] std::io::Error),
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+}
+
+pub type RegistryResult<T> = Result<T, RegistryError>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
+#[error("{field}: {message}")]
+pub struct ValidationError {
+    pub field: String,
+    pub message: String,
+}
+
+impl ValidationError {
+    pub fn new(field: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            field: field.into(),
+            message: message.into(),
+        }
+    }
+}
+
+macro_rules! domain_enum {
+    ($name:ident { $($variant:ident => $value:literal),+ $(,)? }) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+        #[serde(rename_all = "snake_case")]
+        pub enum $name {
+            $($variant),+
+        }
+
+        impl $name {
+            pub fn as_str(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $value),+
+                }
+            }
+
+            pub fn parse(value: &str) -> Result<Self, ValidationError> {
+                value.parse()
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(self.as_str())
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = ValidationError;
+
+            fn from_str(value: &str) -> Result<Self, Self::Err> {
+                match normalize_token(value).as_str() {
+                    $($value => Ok(Self::$variant),)+
+                    _ => Err(ValidationError::new(
+                        stringify!($name),
+                        format!("unsupported value '{value}'"),
+                    )),
+                }
+            }
+        }
+    };
+}
+
+pub(crate) fn normalize_token(input: &str) -> String {
+    input.trim().to_ascii_lowercase().replace('-', "_")
+}
+
+domain_enum!(AssetType {
+    File => "file",
+    Directory => "directory",
+    Dataset => "dataset",
+    Table => "table",
+    ModelArtifact => "model_artifact",
+    ReportArtifact => "report_artifact",
+    ManifestCollection => "manifest_collection",
+});
+
+domain_enum!(DataQuality {
+    Production => "production",
+    Qualified => "qualified",
+    Unverified => "unverified",
+});
+
+domain_enum!(Classification {
+    Public => "public",
+    Internal => "internal",
+    Restricted => "restricted",
+});
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SourceReference {
+    UnixPath(PathBuf),
+}
+
+impl SourceReference {
+    pub fn unix_path(path: PathBuf) -> Result<Self, ValidationError> {
+        if path.as_os_str().is_empty() {
+            return Err(ValidationError::new("source_path", "must not be empty"));
+        }
+        Ok(Self::UnixPath(path))
+    }
+
+    pub fn as_display_string(&self) -> String {
+        match self {
+            Self::UnixPath(path) => path.to_string_lossy().into_owned(),
+        }
+    }
+}
+
+pub fn validate_positive_id(field: &str, value: i64) -> Result<(), ValidationError> {
+    if value > 0 {
+        Ok(())
+    } else {
+        Err(ValidationError::new(field, "must be a positive integer"))
+    }
+}
+
+pub fn validate_product_name(value: &str) -> Result<(), ValidationError> {
+    validate_non_blank("name", value)?;
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == ' ' || ch == '_' || ch == '-')
+    {
+        Ok(())
+    } else {
+        Err(ValidationError::new(
+            "name",
+            "may contain only ASCII letters, numbers, spaces, underscores, and hyphens",
+        ))
+    }
+}
+
+pub fn validate_version_label(value: &str) -> Result<(), ValidationError> {
+    validate_non_blank("version", value)?;
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '.' || ch == '_' || ch == '-')
+    {
+        Ok(())
+    } else {
+        Err(ValidationError::new(
+            "version",
+            "may contain only ASCII letters, numbers, dots, underscores, and hyphens",
+        ))
+    }
+}
+
+pub fn validate_non_blank(field: &str, value: &str) -> Result<(), ValidationError> {
+    if value.trim().is_empty() {
+        Err(ValidationError::new(field, "must not be blank"))
+    } else {
+        Ok(())
+    }
+}
+
+pub fn validate_optional_text(field: &str, value: Option<&str>) -> Result<(), ValidationError> {
+    if let Some(value) = value {
+        validate_non_blank(field, value)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_domain_enums() {
+        assert_eq!("file".parse::<AssetType>().unwrap(), AssetType::File);
+        assert_eq!(
+            "model-artifact".parse::<AssetType>().unwrap(),
+            AssetType::ModelArtifact
+        );
+        assert_eq!(
+            "PRODUCTION".parse::<DataQuality>().unwrap(),
+            DataQuality::Production
+        );
+        assert_eq!(
+            "restricted".parse::<Classification>().unwrap(),
+            Classification::Restricted
+        );
+        assert!("gold".parse::<DataQuality>().is_err());
+        assert!("silver".parse::<DataQuality>().is_err());
+        assert!("bronze".parse::<DataQuality>().is_err());
+    }
+
+    #[test]
+    fn validates_product_names_and_versions() {
+        assert!(validate_product_name("Daily Observations_2026").is_ok());
+        assert!(validate_product_name(" ").is_err());
+        assert!(validate_product_name("bad/name").is_err());
+        assert!(validate_version_label("v1.0_2026-07").is_ok());
+        assert!(validate_version_label("v 1").is_err());
+        assert!(validate_version_label("v1/slash").is_err());
+    }
+
+    #[test]
+    fn validates_ids_text_and_sources() {
+        assert!(validate_positive_id("product_id", 1).is_ok());
+        assert!(validate_positive_id("product_id", 0).is_err());
+        assert!(validate_optional_text("description", Some("  ")).is_err());
+        assert!(SourceReference::unix_path(PathBuf::from("/tmp/data with spaces.csv")).is_ok());
+    }
+}

--- a/feather-mesh/mesh_core/src/domain.rs
+++ b/feather-mesh/mesh_core/src/domain.rs
@@ -44,7 +44,7 @@ impl ValidationError {
 }
 
 macro_rules! domain_enum {
-    ($name:ident { $($variant:ident => $value:literal),+ $(,)? }) => {
+    ($name:ident, $field:literal { $($variant:ident => $value:literal),+ $(,)? }) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
         #[serde(rename_all = "snake_case")]
         pub enum $name {
@@ -56,10 +56,6 @@ macro_rules! domain_enum {
                 match self {
                     $(Self::$variant => $value),+
                 }
-            }
-
-            pub fn parse(value: &str) -> Result<Self, ValidationError> {
-                value.parse()
             }
         }
 
@@ -76,7 +72,7 @@ macro_rules! domain_enum {
                 match normalize_token(value).as_str() {
                     $($value => Ok(Self::$variant),)+
                     _ => Err(ValidationError::new(
-                        stringify!($name),
+                        $field,
                         format!("unsupported value '{value}'"),
                     )),
                 }
@@ -89,7 +85,7 @@ pub(crate) fn normalize_token(input: &str) -> String {
     input.trim().to_ascii_lowercase().replace('-', "_")
 }
 
-domain_enum!(AssetType {
+domain_enum!(AssetType, "asset_type" {
     File => "file",
     Directory => "directory",
     Dataset => "dataset",
@@ -99,13 +95,13 @@ domain_enum!(AssetType {
     ManifestCollection => "manifest_collection",
 });
 
-domain_enum!(DataQuality {
+domain_enum!(DataQuality, "data_quality" {
     Production => "production",
     Qualified => "qualified",
     Unverified => "unverified",
 });
 
-domain_enum!(Classification {
+domain_enum!(Classification, "classification" {
     Public => "public",
     Internal => "internal",
     Restricted => "restricted",

--- a/feather-mesh/mesh_core/src/lib.rs
+++ b/feather-mesh/mesh_core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod db;
+pub mod domain;
 pub mod models;
 pub mod repositories;
 pub mod services;

--- a/feather-mesh/mesh_core/src/models/entities/data_product.rs
+++ b/feather-mesh/mesh_core/src/models/entities/data_product.rs
@@ -7,6 +7,8 @@ pub struct DataProduct {
     pub name: String,
     pub description: Option<String>,
     pub owner_team_id: i64,
+    pub producer: String,
+    pub usage_policy: String,
     pub intended_use: Option<String>,
     pub created_at: NaiveDateTime,
 }
@@ -26,6 +28,8 @@ mod tests {
             name: "Orders".to_string(),
             description: Some("Order facts curated for finance reporting".to_string()),
             owner_team_id: 2,
+            producer: "Finance".to_string(),
+            usage_policy: "Internal analytics only".to_string(),
             intended_use: Some("Monthly reconciliations".to_string()),
             created_at,
         };
@@ -36,6 +40,7 @@ mod tests {
         assert!(json.contains("\"product_id\":11"));
         assert!(json.contains("\"name\":\"Orders\""));
         assert!(json.contains("\"owner_team_id\":2"));
+        assert!(json.contains("\"producer\":\"Finance\""));
         assert_eq!(round_trip, product);
     }
 }

--- a/feather-mesh/mesh_core/src/models/entities/data_product_version.rs
+++ b/feather-mesh/mesh_core/src/models/entities/data_product_version.rs
@@ -9,7 +9,7 @@ pub struct DataProductVersion {
     pub asset_type: String,
     pub source_path: String,
     pub data_quality: String,
-    pub classification: Option<String>,
+    pub classification: String,
     pub created_at: NaiveDateTime,
 }
 
@@ -30,7 +30,7 @@ mod tests {
             asset_type: "test".to_string(),
             source_path: "test/data".to_string(),
             data_quality: "test".to_string(),
-            classification: Some("test".to_string()),
+            classification: "internal".to_string(),
             created_at,
         };
 
@@ -40,6 +40,7 @@ mod tests {
         assert!(json.contains("\"version_id\":8"));
         assert!(json.contains("\"data_product_id\":3"));
         assert!(json.contains("\"version_label\":\"2026.03\""));
+        assert!(json.contains("\"classification\":\"internal\""));
         assert_eq!(round_trip, version);
     }
 }

--- a/feather-mesh/mesh_core/src/models/new/data_product.rs
+++ b/feather-mesh/mesh_core/src/models/new/data_product.rs
@@ -5,6 +5,8 @@ pub struct NewDataProduct {
     pub name: String,
     pub description: Option<String>,
     pub owner_team_id: i64,
+    pub producer: String,
+    pub usage_policy: String,
     pub intended_use: Option<String>,
 }
 
@@ -14,12 +16,16 @@ impl NewDataProduct {
         name: String,
         description: Option<String>,
         owner_team_id: i64,
+        producer: String,
+        usage_policy: String,
         intended_use: Option<String>,
     ) -> Self {
         Self {
             name,
             description,
             owner_team_id,
+            producer,
+            usage_policy,
             intended_use,
         }
     }
@@ -32,11 +38,20 @@ mod tests {
     #[test]
     // Verifies the constructor leaves optional fields unset and preserves input values.
     fn new_data_product_initializes_insert_model_with_optional_fields_to_none() {
-        let product = NewDataProduct::new("Orders".to_string(), None, 5, None);
+        let product = NewDataProduct::new(
+            "Orders".to_string(),
+            None,
+            5,
+            "Finance".to_string(),
+            "Internal use".to_string(),
+            None,
+        );
 
         assert_eq!(product.name, "Orders");
         assert_eq!(product.description, None);
         assert_eq!(product.owner_team_id, 5);
+        assert_eq!(product.producer, "Finance");
+        assert_eq!(product.usage_policy, "Internal use");
         assert_eq!(product.intended_use, None);
     }
 
@@ -47,6 +62,8 @@ mod tests {
             "Orders".to_string(),
             Some("Order facts curated for finance reporting".to_string()),
             5,
+            "Finance".to_string(),
+            "Internal use".to_string(),
             Some("Monthly reconciliations".to_string()),
         );
 

--- a/feather-mesh/mesh_core/src/models/new/data_product_version.rs
+++ b/feather-mesh/mesh_core/src/models/new/data_product_version.rs
@@ -7,7 +7,7 @@ pub struct NewDataProductVersion {
     pub asset_type: String,
     pub source_path: String,
     pub data_quality: String,
-    pub classification: Option<String>,
+    pub classification: String,
 }
 
 impl NewDataProductVersion {
@@ -18,7 +18,7 @@ impl NewDataProductVersion {
         asset_type: String,
         source_path: String,
         data_quality: String,
-        classification: Option<String>,
+        classification: String,
     ) -> Self {
         Self {
             data_product_id,
@@ -37,14 +37,14 @@ mod tests {
 
     #[test]
     // Verifies the constructor leaves optional fields unset and preserves input values.
-    fn new_data_product_version_initializes_insert_model_with_optional_fields_to_none() {
+    fn new_data_product_version_initializes_insert_model() {
         let version = NewDataProductVersion::new(
             12,
             "v1.0.0".to_string(),
             "test".to_string(),
             "test/data".to_string(),
             "test".to_string(),
-            None,
+            "internal".to_string(),
         );
 
         assert_eq!(version.data_product_id, 12);
@@ -52,21 +52,6 @@ mod tests {
         assert_eq!(version.asset_type, "test");
         assert_eq!(version.source_path, "test/data");
         assert_eq!(version.data_quality, "test");
-        assert_eq!(version.classification, None);
-    }
-
-    #[test]
-    // Verifies the constructor preserves optional user-provided values.
-    fn new_data_product_version_preserves_optional_fields() {
-        let version = NewDataProductVersion::new(
-            12,
-            "v1.0.0".to_string(),
-            "test".to_string(),
-            "test/data".to_string(),
-            "test".to_string(),
-            Some("internal".to_string()),
-        );
-
-        assert_eq!(version.classification, Some("internal".to_string()));
+        assert_eq!(version.classification, "internal");
     }
 }

--- a/feather-mesh/mesh_core/src/repositories/data_product_repository.rs
+++ b/feather-mesh/mesh_core/src/repositories/data_product_repository.rs
@@ -53,49 +53,37 @@ impl DataProductRepository {
     }
 
     pub fn get_all_by_asset_type(conn: &Connection, asset_type: &str) -> Result<Vec<DataProduct>> {
-        let mut query = conn.prepare(
-            "SELECT DISTINCT p.product_id, p.name, p.description, p.owner_team_id, p.producer,
-                    p.usage_policy, p.intended_use, p.created_at
-             FROM data_products p
-             INNER JOIN data_product_versions v ON v.data_product_id = p.product_id
-             WHERE LOWER(v.asset_type) = LOWER(?1)
-             ORDER BY p.product_id",
-        )?;
-        let rows = query.query_map(params![asset_type], Self::from_row)?;
-
-        rows.collect()
+        Self::get_all_by_version_column(conn, "asset_type", asset_type)
     }
 
     pub fn get_all_by_data_quality(
         conn: &Connection,
         data_quality: &str,
     ) -> Result<Vec<DataProduct>> {
-        let mut query = conn.prepare(
-            "SELECT DISTINCT p.product_id, p.name, p.description, p.owner_team_id, p.producer,
-                    p.usage_policy, p.intended_use, p.created_at
-             FROM data_products p
-             INNER JOIN data_product_versions v ON v.data_product_id = p.product_id
-             WHERE LOWER(v.data_quality) = LOWER(?1)
-             ORDER BY p.product_id",
-        )?;
-        let rows = query.query_map(params![data_quality], Self::from_row)?;
-
-        rows.collect()
+        Self::get_all_by_version_column(conn, "data_quality", data_quality)
     }
 
     pub fn get_all_by_classification(
         conn: &Connection,
         classification: &str,
     ) -> Result<Vec<DataProduct>> {
-        let mut query = conn.prepare(
+        Self::get_all_by_version_column(conn, "classification", classification)
+    }
+
+    fn get_all_by_version_column(
+        conn: &Connection,
+        column: &str,
+        value: &str,
+    ) -> Result<Vec<DataProduct>> {
+        let mut query = conn.prepare(&format!(
             "SELECT DISTINCT p.product_id, p.name, p.description, p.owner_team_id, p.producer,
                     p.usage_policy, p.intended_use, p.created_at
              FROM data_products p
              INNER JOIN data_product_versions v ON v.data_product_id = p.product_id
-             WHERE LOWER(v.classification) = LOWER(?1)
-             ORDER BY p.product_id",
-        )?;
-        let rows = query.query_map(params![classification], Self::from_row)?;
+             WHERE LOWER(v.{column}) = LOWER(?1)
+             ORDER BY p.product_id"
+        ))?;
+        let rows = query.query_map(params![value], Self::from_row)?;
 
         rows.collect()
     }

--- a/feather-mesh/mesh_core/src/repositories/data_product_repository.rs
+++ b/feather-mesh/mesh_core/src/repositories/data_product_repository.rs
@@ -10,12 +10,15 @@ impl DataProductRepository {
     /// Inserts a new data product and returns the persisted data product row with database-managed fields.
     pub fn create(conn: &Connection, input: NewDataProduct) -> Result<DataProduct> {
         conn.execute(
-            "INSERT INTO data_products (name, description, owner_team_id, intended_use)
-             VALUES (?1, ?2, ?3, ?4)",
+            "INSERT INTO data_products
+                (name, description, owner_team_id, producer, usage_policy, intended_use)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
                 input.name,
                 input.description,
                 input.owner_team_id,
+                input.producer,
+                input.usage_policy,
                 input.intended_use
             ],
         )?;
@@ -27,7 +30,8 @@ impl DataProductRepository {
     /// Gets a persisted data product by product_id.
     pub fn get_by_id(conn: &Connection, product_id: i64) -> Result<DataProduct> {
         conn.query_row(
-            "SELECT product_id, name, description, owner_team_id, intended_use, created_at
+            "SELECT product_id, name, description, owner_team_id, producer, usage_policy,
+                    intended_use, created_at
              FROM data_products
              WHERE product_id = ?1",
             params![product_id],
@@ -38,11 +42,60 @@ impl DataProductRepository {
     /// Gets all persisted data products ordered by primary key.
     pub fn get_all(conn: &Connection) -> Result<Vec<DataProduct>> {
         let mut query = conn.prepare(
-            "SELECT product_id, name, description, owner_team_id, intended_use, created_at
+            "SELECT product_id, name, description, owner_team_id, producer, usage_policy,
+                    intended_use, created_at
              FROM data_products
              ORDER BY product_id",
         )?;
         let rows = query.query_map([], Self::from_row)?;
+
+        rows.collect()
+    }
+
+    pub fn get_all_by_asset_type(conn: &Connection, asset_type: &str) -> Result<Vec<DataProduct>> {
+        let mut query = conn.prepare(
+            "SELECT DISTINCT p.product_id, p.name, p.description, p.owner_team_id, p.producer,
+                    p.usage_policy, p.intended_use, p.created_at
+             FROM data_products p
+             INNER JOIN data_product_versions v ON v.data_product_id = p.product_id
+             WHERE LOWER(v.asset_type) = LOWER(?1)
+             ORDER BY p.product_id",
+        )?;
+        let rows = query.query_map(params![asset_type], Self::from_row)?;
+
+        rows.collect()
+    }
+
+    pub fn get_all_by_data_quality(
+        conn: &Connection,
+        data_quality: &str,
+    ) -> Result<Vec<DataProduct>> {
+        let mut query = conn.prepare(
+            "SELECT DISTINCT p.product_id, p.name, p.description, p.owner_team_id, p.producer,
+                    p.usage_policy, p.intended_use, p.created_at
+             FROM data_products p
+             INNER JOIN data_product_versions v ON v.data_product_id = p.product_id
+             WHERE LOWER(v.data_quality) = LOWER(?1)
+             ORDER BY p.product_id",
+        )?;
+        let rows = query.query_map(params![data_quality], Self::from_row)?;
+
+        rows.collect()
+    }
+
+    pub fn get_all_by_classification(
+        conn: &Connection,
+        classification: &str,
+    ) -> Result<Vec<DataProduct>> {
+        let mut query = conn.prepare(
+            "SELECT DISTINCT p.product_id, p.name, p.description, p.owner_team_id, p.producer,
+                    p.usage_policy, p.intended_use, p.created_at
+             FROM data_products p
+             INNER JOIN data_product_versions v ON v.data_product_id = p.product_id
+             WHERE LOWER(v.classification) = LOWER(?1)
+             ORDER BY p.product_id",
+        )?;
+        let rows = query.query_map(params![classification], Self::from_row)?;
 
         rows.collect()
     }
@@ -56,8 +109,10 @@ impl DataProductRepository {
             name: row.get("name")?,
             description: row.get("description")?,
             owner_team_id: row.get("owner_team_id")?,
+            producer: row.get("producer")?,
+            usage_policy: row.get("usage_policy")?,
             intended_use: row.get("intended_use")?,
-            created_at: parse_naive_datetime(5, created_at)?,
+            created_at: parse_naive_datetime(7, created_at)?,
         })
     }
 }

--- a/feather-mesh/mesh_core/src/repositories/data_product_version_repository.rs
+++ b/feather-mesh/mesh_core/src/repositories/data_product_version_repository.rs
@@ -30,10 +30,7 @@ impl DataProductVersionRepository {
     /// Gets a persisted data product version by its primary key.
     pub fn get_by_id(conn: &Connection, version_id: i64) -> Result<DataProductVersion> {
         conn.query_row(
-            "SELECT version_id, data_product_id, version_label, asset_type, source_path,
-                    data_quality, classification, created_at
-             FROM data_product_versions
-             WHERE version_id = ?1",
+            &Self::select_sql("WHERE version_id = ?1"),
             params![version_id],
             Self::from_row,
         )
@@ -45,12 +42,7 @@ impl DataProductVersionRepository {
         version_label: &str,
     ) -> Result<DataProductVersion> {
         conn.query_row(
-            "SELECT version_id, data_product_id, version_label, asset_type, source_path,
-                    data_quality, classification, created_at
-             FROM data_product_versions
-             WHERE data_product_id = ?1 AND version_label = ?2
-             ORDER BY version_id DESC
-             LIMIT 1",
+            &Self::select_sql("WHERE data_product_id = ?1 AND version_label = ?2"),
             params![product_id, version_label],
             Self::from_row,
         )
@@ -61,12 +53,7 @@ impl DataProductVersionRepository {
         product_id: i64,
     ) -> Result<DataProductVersion> {
         conn.query_row(
-            "SELECT version_id, data_product_id, version_label, asset_type, source_path,
-                    data_quality, classification, created_at
-             FROM data_product_versions
-             WHERE data_product_id = ?1
-             ORDER BY version_id DESC
-             LIMIT 1",
+            &Self::select_sql("WHERE data_product_id = ?1 ORDER BY version_id DESC LIMIT 1"),
             params![product_id],
             Self::from_row,
         )
@@ -74,37 +61,23 @@ impl DataProductVersionRepository {
 
     pub fn get_by_source_path(conn: &Connection, source_path: &str) -> Result<DataProductVersion> {
         conn.query_row(
-            "SELECT version_id, data_product_id, version_label, asset_type, source_path,
-                    data_quality, classification, created_at
-             FROM data_product_versions
-             WHERE source_path = ?1
-             ORDER BY version_id DESC
-             LIMIT 1",
+            &Self::select_sql("WHERE source_path = ?1"),
             params![source_path],
             Self::from_row,
         )
     }
 
     pub fn get_for_product(conn: &Connection, product_id: i64) -> Result<Vec<DataProductVersion>> {
-        let mut stmt = conn.prepare(
-            "SELECT version_id, data_product_id, version_label, asset_type, source_path,
-                    data_quality, classification, created_at
-             FROM data_product_versions
-             WHERE data_product_id = ?1
-             ORDER BY version_id",
-        )?;
+        let mut stmt = conn.prepare(&Self::select_sql(
+            "WHERE data_product_id = ?1 ORDER BY version_id",
+        ))?;
         let rows = stmt.query_map(params![product_id], Self::from_row)?;
         rows.collect()
     }
 
     /// Gets all persisted data product versions ordered by primary key.
     pub fn get_all(conn: &Connection) -> Result<Vec<DataProductVersion>> {
-        let mut stmt = conn.prepare(
-            "SELECT version_id, data_product_id, version_label, asset_type, source_path,
-                    data_quality, classification, created_at
-             FROM data_product_versions
-             ORDER BY version_id",
-        )?;
+        let mut stmt = conn.prepare(&Self::select_sql("ORDER BY version_id"))?;
         let rows = stmt.query_map([], Self::from_row)?;
 
         rows.collect()
@@ -114,48 +87,43 @@ impl DataProductVersionRepository {
         conn: &Connection,
         asset_type: &str,
     ) -> Result<Vec<DataProductVersion>> {
-        let mut stmt = conn.prepare(
-            "SELECT version_id, data_product_id, version_label, asset_type, source_path,
-                    data_quality, classification, created_at
-             FROM data_product_versions
-             WHERE LOWER(asset_type) = LOWER(?1)
-             ORDER BY version_id",
-        )?;
-        let rows = stmt.query_map(params![asset_type], Self::from_row)?;
-
-        rows.collect()
+        Self::get_all_by_column(conn, "asset_type", asset_type)
     }
 
     pub fn get_all_by_data_quality(
         conn: &Connection,
         data_quality: &str,
     ) -> Result<Vec<DataProductVersion>> {
-        let mut stmt = conn.prepare(
-            "SELECT version_id, data_product_id, version_label, asset_type, source_path,
-                    data_quality, classification, created_at
-             FROM data_product_versions
-             WHERE LOWER(data_quality) = LOWER(?1)
-             ORDER BY version_id",
-        )?;
-        let rows = stmt.query_map(params![data_quality], Self::from_row)?;
-
-        rows.collect()
+        Self::get_all_by_column(conn, "data_quality", data_quality)
     }
 
     pub fn get_all_by_classification(
         conn: &Connection,
         classification: &str,
     ) -> Result<Vec<DataProductVersion>> {
-        let mut stmt = conn.prepare(
+        Self::get_all_by_column(conn, "classification", classification)
+    }
+
+    fn get_all_by_column(
+        conn: &Connection,
+        column: &str,
+        value: &str,
+    ) -> Result<Vec<DataProductVersion>> {
+        let mut stmt = conn.prepare(&Self::select_sql(&format!(
+            "WHERE LOWER({column}) = LOWER(?1) ORDER BY version_id"
+        )))?;
+        let rows = stmt.query_map(params![value], Self::from_row)?;
+
+        rows.collect()
+    }
+
+    fn select_sql(clause: &str) -> String {
+        format!(
             "SELECT version_id, data_product_id, version_label, asset_type, source_path,
                     data_quality, classification, created_at
              FROM data_product_versions
-             WHERE LOWER(classification) = LOWER(?1)
-             ORDER BY version_id",
-        )?;
-        let rows = stmt.query_map(params![classification], Self::from_row)?;
-
-        rows.collect()
+             {clause}"
+        )
     }
 
     /// Maps database row -> DataProductVersion struct

--- a/feather-mesh/mesh_core/src/repositories/data_product_version_repository.rs
+++ b/feather-mesh/mesh_core/src/repositories/data_product_version_repository.rs
@@ -39,6 +39,64 @@ impl DataProductVersionRepository {
         )
     }
 
+    pub fn get_by_product_and_label(
+        conn: &Connection,
+        product_id: i64,
+        version_label: &str,
+    ) -> Result<DataProductVersion> {
+        conn.query_row(
+            "SELECT version_id, data_product_id, version_label, asset_type, source_path,
+                    data_quality, classification, created_at
+             FROM data_product_versions
+             WHERE data_product_id = ?1 AND version_label = ?2
+             ORDER BY version_id DESC
+             LIMIT 1",
+            params![product_id, version_label],
+            Self::from_row,
+        )
+    }
+
+    pub fn get_latest_for_product(
+        conn: &Connection,
+        product_id: i64,
+    ) -> Result<DataProductVersion> {
+        conn.query_row(
+            "SELECT version_id, data_product_id, version_label, asset_type, source_path,
+                    data_quality, classification, created_at
+             FROM data_product_versions
+             WHERE data_product_id = ?1
+             ORDER BY version_id DESC
+             LIMIT 1",
+            params![product_id],
+            Self::from_row,
+        )
+    }
+
+    pub fn get_by_source_path(conn: &Connection, source_path: &str) -> Result<DataProductVersion> {
+        conn.query_row(
+            "SELECT version_id, data_product_id, version_label, asset_type, source_path,
+                    data_quality, classification, created_at
+             FROM data_product_versions
+             WHERE source_path = ?1
+             ORDER BY version_id DESC
+             LIMIT 1",
+            params![source_path],
+            Self::from_row,
+        )
+    }
+
+    pub fn get_for_product(conn: &Connection, product_id: i64) -> Result<Vec<DataProductVersion>> {
+        let mut stmt = conn.prepare(
+            "SELECT version_id, data_product_id, version_label, asset_type, source_path,
+                    data_quality, classification, created_at
+             FROM data_product_versions
+             WHERE data_product_id = ?1
+             ORDER BY version_id",
+        )?;
+        let rows = stmt.query_map(params![product_id], Self::from_row)?;
+        rows.collect()
+    }
+
     /// Gets all persisted data product versions ordered by primary key.
     pub fn get_all(conn: &Connection) -> Result<Vec<DataProductVersion>> {
         let mut stmt = conn.prepare(
@@ -48,6 +106,54 @@ impl DataProductVersionRepository {
              ORDER BY version_id",
         )?;
         let rows = stmt.query_map([], Self::from_row)?;
+
+        rows.collect()
+    }
+
+    pub fn get_all_by_asset_type(
+        conn: &Connection,
+        asset_type: &str,
+    ) -> Result<Vec<DataProductVersion>> {
+        let mut stmt = conn.prepare(
+            "SELECT version_id, data_product_id, version_label, asset_type, source_path,
+                    data_quality, classification, created_at
+             FROM data_product_versions
+             WHERE LOWER(asset_type) = LOWER(?1)
+             ORDER BY version_id",
+        )?;
+        let rows = stmt.query_map(params![asset_type], Self::from_row)?;
+
+        rows.collect()
+    }
+
+    pub fn get_all_by_data_quality(
+        conn: &Connection,
+        data_quality: &str,
+    ) -> Result<Vec<DataProductVersion>> {
+        let mut stmt = conn.prepare(
+            "SELECT version_id, data_product_id, version_label, asset_type, source_path,
+                    data_quality, classification, created_at
+             FROM data_product_versions
+             WHERE LOWER(data_quality) = LOWER(?1)
+             ORDER BY version_id",
+        )?;
+        let rows = stmt.query_map(params![data_quality], Self::from_row)?;
+
+        rows.collect()
+    }
+
+    pub fn get_all_by_classification(
+        conn: &Connection,
+        classification: &str,
+    ) -> Result<Vec<DataProductVersion>> {
+        let mut stmt = conn.prepare(
+            "SELECT version_id, data_product_id, version_label, asset_type, source_path,
+                    data_quality, classification, created_at
+             FROM data_product_versions
+             WHERE LOWER(classification) = LOWER(?1)
+             ORDER BY version_id",
+        )?;
+        let rows = stmt.query_map(params![classification], Self::from_row)?;
 
         rows.collect()
     }

--- a/feather-mesh/mesh_core/src/repositories/lineage_dependency_repository.rs
+++ b/feather-mesh/mesh_core/src/repositories/lineage_dependency_repository.rs
@@ -45,6 +45,20 @@ impl LineageDependencyRepository {
         rows.collect()
     }
 
+    pub fn get_by_downstream_version(
+        conn: &Connection,
+        downstream_version_id: i64,
+    ) -> Result<Vec<LineageDependency>> {
+        let mut stmt = conn.prepare(
+            "SELECT dependency_id, downstream_version_id, upstream_product_uri, upstream_version
+             FROM lineage_dependencies
+             WHERE downstream_version_id = ?1
+             ORDER BY dependency_id",
+        )?;
+        let rows = stmt.query_map(params![downstream_version_id], Self::from_row)?;
+        rows.collect()
+    }
+
     /// Maps a database row -> LineageDependency struct
     fn from_row(row: &Row<'_>) -> Result<LineageDependency> {
         Ok(LineageDependency {

--- a/feather-mesh/mesh_core/src/repositories/team_repository.rs
+++ b/feather-mesh/mesh_core/src/repositories/team_repository.rs
@@ -24,6 +24,14 @@ impl TeamRepository {
         )
     }
 
+    pub fn get_by_name(conn: &Connection, name: &str) -> Result<Team> {
+        conn.query_row(
+            "SELECT team_id, name, created_at FROM teams WHERE lower(name) = lower(?1)",
+            params![name],
+            Self::from_row,
+        )
+    }
+
     /// Gets all persisted teams ordered by primary key.
     pub fn get_all(conn: &Connection) -> Result<Vec<Team>> {
         let mut query =

--- a/feather-mesh/mesh_core/src/services/mod.rs
+++ b/feather-mesh/mesh_core/src/services/mod.rs
@@ -1,3 +1,10 @@
 pub mod registry_service;
+pub mod requests;
 
-pub use registry_service::RegistryService;
+pub use registry_service::{
+    ConsumeReceipt, ConsumeRequest, InitResponse, LineageReference, LineageResponse, ProductDetail,
+    ProductSummary, RegistryService, SearchRequest, ServeRequest, ServeResponse,
+};
+pub use requests::{
+    CreateDataProductRequest, CreateDataProductVersionRequest, CreateLineageDependencyRequest,
+};

--- a/feather-mesh/mesh_core/src/services/registry_service.rs
+++ b/feather-mesh/mesh_core/src/services/registry_service.rs
@@ -1,28 +1,654 @@
-use rusqlite::{Connection, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
 
-use crate::models::{NewTeam, Team};
-use crate::repositories::TeamRepository;
+use chrono::Utc;
+use rusqlite::{Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
 
-// RegistryService exposes API-style registry workflows for `mesh_cli`.
+use crate::domain::{
+    AssetType, Classification, DataQuality, RegistryError, RegistryResult, SourceReference,
+    validate_non_blank, validate_optional_text, validate_positive_id, validate_product_name,
+    validate_version_label,
+};
+use crate::models::{
+    DataProduct, DataProductVersion, LineageDependency, NewDataProduct, NewDataProductVersion,
+    NewLineageDependency, NewTeam, Team,
+};
+use crate::repositories::{
+    DataProductRepository, DataProductVersionRepository, LineageDependencyRepository,
+    TeamRepository,
+};
+use crate::services::{
+    CreateDataProductRequest, CreateDataProductVersionRequest, CreateLineageDependencyRequest,
+};
 
-// note: `a -> lifetime of the connection reference, ensures registry service does not outlive the db connection it uses
 pub struct RegistryService<'a> {
     conn: &'a Connection,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServeRequest {
+    pub source_path: PathBuf,
+    pub name: String,
+    pub asset_type: AssetType,
+    pub version: String,
+    pub owner_team: String,
+    pub producer: String,
+    pub usage_policy: String,
+    pub data_quality: DataQuality,
+    pub classification: Classification,
+    pub description: Option<String>,
+    pub intended_use: Option<String>,
+    #[serde(default)]
+    pub lineage: Vec<LineageReference>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LineageReference {
+    pub source: String,
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServeResponse {
+    pub product_id: i64,
+    pub version_id: i64,
+    pub name: String,
+    pub version: String,
+    pub source_reference: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchRequest {
+    pub query: Option<String>,
+    pub asset_type: Option<AssetType>,
+    pub data_quality: Option<DataQuality>,
+    pub classification: Option<Classification>,
+    pub owner_team: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProductSummary {
+    pub product_id: i64,
+    pub name: String,
+    pub owner_team: String,
+    pub producer: String,
+    pub version: Option<String>,
+    pub asset_type: Option<String>,
+    pub data_quality: Option<String>,
+    pub classification: Option<String>,
+    pub source_reference: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProductDetail {
+    pub product_id: i64,
+    pub name: String,
+    pub description: Option<String>,
+    pub owner_team: String,
+    pub producer: String,
+    pub usage_policy: String,
+    pub intended_use: Option<String>,
+    pub created_at: String,
+    pub selected_version: VersionDetail,
+    pub lineage: LineageResponse,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VersionDetail {
+    pub version_id: i64,
+    pub version: String,
+    pub asset_type: String,
+    pub source_reference: String,
+    pub data_quality: String,
+    pub classification: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LineageResponse {
+    pub product_id: i64,
+    pub version: String,
+    pub status: String,
+    pub dependencies: Vec<LineageDependencyDetail>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LineageDependencyDetail {
+    pub upstream_source_reference: String,
+    pub upstream_version: Option<String>,
+    pub upstream_product_id: Option<i64>,
+    pub upstream_name: Option<String>,
+    pub upstream_producer: Option<String>,
+    pub upstream_published_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConsumeRequest {
+    pub product_ref: String,
+    pub version: String,
+    pub out: PathBuf,
+    pub overwrite: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConsumeReceipt {
+    pub product_id: i64,
+    pub version: String,
+    pub source_reference: String,
+    pub output_path: String,
+    pub retrieved_at: String,
+    pub checksum: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InitResponse {
+    pub registry_path: String,
+    pub status: String,
+}
+
 impl<'a> RegistryService<'a> {
-    /// Creates a registry service backed by an existing database connection.
     pub fn new(conn: &'a Connection) -> Self {
         Self { conn }
     }
 
-    /// Registers a team in the registry and returns the persisted team.
-    pub fn register_team(&self, name: String) -> Result<Team> {
-        TeamRepository::create(self.conn, NewTeam::new(name))
+    pub fn register_team(&self, name: String) -> RegistryResult<Team> {
+        validate_non_blank("team", &name)?;
+        TeamRepository::create(self.conn, NewTeam::new(name)).map_err(RegistryError::from)
     }
 
-    /// Returns all teams currently registered in the registry.
-    pub fn list_teams(&self) -> Result<Vec<Team>> {
-        TeamRepository::get_all(self.conn)
+    pub fn list_teams(&self) -> RegistryResult<Vec<Team>> {
+        TeamRepository::get_all(self.conn).map_err(RegistryError::from)
+    }
+
+    pub fn list_products(&self) -> RegistryResult<Vec<ProductSummary>> {
+        self.search_products(SearchRequest {
+            query: None,
+            asset_type: None,
+            data_quality: None,
+            classification: None,
+            owner_team: None,
+        })
+    }
+
+    pub fn register_data_product(
+        &self,
+        input: CreateDataProductRequest,
+    ) -> RegistryResult<DataProduct> {
+        validate_product_name(&input.name)?;
+        validate_positive_id("owner_team_id", input.owner_team_id)?;
+        validate_optional_text("description", input.description.as_deref())?;
+        validate_optional_text("intended_use", input.intended_use.as_deref())?;
+        validate_non_blank("producer", &input.producer)?;
+        validate_non_blank("usage_policy", &input.usage_policy)?;
+        TeamRepository::get_by_id(self.conn, input.owner_team_id).map_err(|err| {
+            if matches!(err, rusqlite::Error::QueryReturnedNoRows) {
+                RegistryError::NotFound(format!("owner team '{}'", input.owner_team_id))
+            } else {
+                RegistryError::Database(err)
+            }
+        })?;
+        DataProductRepository::create(
+            self.conn,
+            NewDataProduct::new(
+                input.name,
+                input.description,
+                input.owner_team_id,
+                input.producer,
+                input.usage_policy,
+                input.intended_use,
+            ),
+        )
+        .map_err(RegistryError::from)
+    }
+
+    pub fn register_data_product_version(
+        &self,
+        input: CreateDataProductVersionRequest,
+    ) -> RegistryResult<DataProductVersion> {
+        validate_positive_id("data_product_id", input.data_product_id)?;
+        validate_version_label(&input.version_label)?;
+        let asset_type: AssetType = input.asset_type.parse()?;
+        SourceReference::unix_path(PathBuf::from(&input.source_path))?;
+        let data_quality: DataQuality = input.data_quality.parse()?;
+        let classification: Classification = input.classification.parse()?;
+        DataProductRepository::get_by_id(self.conn, input.data_product_id).map_err(|err| {
+            if matches!(err, rusqlite::Error::QueryReturnedNoRows) {
+                RegistryError::NotFound(format!("product '{}'", input.data_product_id))
+            } else {
+                RegistryError::Database(err)
+            }
+        })?;
+        DataProductVersionRepository::create(
+            self.conn,
+            NewDataProductVersion::new(
+                input.data_product_id,
+                input.version_label,
+                asset_type.to_string(),
+                input.source_path,
+                data_quality.to_string(),
+                classification.to_string(),
+            ),
+        )
+        .map_err(RegistryError::from)
+    }
+
+    pub fn register_lineage_dependency(
+        &self,
+        input: CreateLineageDependencyRequest,
+    ) -> RegistryResult<LineageDependency> {
+        validate_positive_id("downstream_version_id", input.downstream_version_id)?;
+        validate_non_blank("upstream_product_uri", &input.upstream_product_uri)?;
+        validate_optional_text("upstream_version", input.upstream_version.as_deref())?;
+        DataProductVersionRepository::get_by_id(self.conn, input.downstream_version_id).map_err(
+            |err| {
+                if matches!(err, rusqlite::Error::QueryReturnedNoRows) {
+                    RegistryError::NotFound(format!(
+                        "downstream version '{}'",
+                        input.downstream_version_id
+                    ))
+                } else {
+                    RegistryError::Database(err)
+                }
+            },
+        )?;
+        LineageDependencyRepository::create(
+            self.conn,
+            NewLineageDependency::new(
+                input.downstream_version_id,
+                input.upstream_product_uri,
+                input.upstream_version,
+            ),
+        )
+        .map_err(RegistryError::from)
+    }
+
+    pub fn validate_serve_request(&self, request: &ServeRequest) -> RegistryResult<()> {
+        SourceReference::unix_path(request.source_path.clone())?;
+        validate_product_name(&request.name)?;
+        validate_version_label(&request.version)?;
+        validate_non_blank("owner_team", &request.owner_team)?;
+        validate_non_blank("producer", &request.producer)?;
+        validate_non_blank("usage_policy", &request.usage_policy)?;
+        validate_optional_text("description", request.description.as_deref())?;
+        validate_optional_text("intended_use", request.intended_use.as_deref())?;
+        for lineage in &request.lineage {
+            validate_non_blank("lineage", &lineage.source)?;
+            validate_optional_text("lineage.version", lineage.version.as_deref())?;
+        }
+        Ok(())
+    }
+
+    pub fn serve(&self, request: ServeRequest) -> RegistryResult<ServeResponse> {
+        self.validate_serve_request(&request)?;
+        let source = SourceReference::unix_path(request.source_path.clone())?.as_display_string();
+        let team = self.get_or_create_team(&request.owner_team)?;
+        let product = DataProductRepository::create(
+            self.conn,
+            NewDataProduct::new(
+                request.name,
+                request.description,
+                team.team_id,
+                request.producer,
+                request.usage_policy,
+                request.intended_use,
+            ),
+        )?;
+        let version = DataProductVersionRepository::create(
+            self.conn,
+            NewDataProductVersion::new(
+                product.product_id,
+                request.version,
+                request.asset_type.to_string(),
+                source.clone(),
+                request.data_quality.to_string(),
+                request.classification.to_string(),
+            ),
+        )?;
+        for lineage in request.lineage {
+            LineageDependencyRepository::create(
+                self.conn,
+                NewLineageDependency::new(version.version_id, lineage.source, lineage.version),
+            )?;
+        }
+        Ok(ServeResponse {
+            product_id: product.product_id,
+            version_id: version.version_id,
+            name: product.name,
+            version: version.version_label,
+            source_reference: source,
+            status: "published".to_string(),
+        })
+    }
+
+    pub fn search_products(&self, request: SearchRequest) -> RegistryResult<Vec<ProductSummary>> {
+        if let Some(owner_team) = request.owner_team.as_deref() {
+            validate_non_blank("owner_team", owner_team)?;
+        }
+
+        let mut stmt = self.conn.prepare(
+            "SELECT p.product_id, p.name, t.name AS owner_team, p.producer,
+                    p.created_at, v.version_label, v.asset_type, v.data_quality,
+                    v.classification, v.source_path
+             FROM data_products p
+             JOIN teams t ON t.team_id = p.owner_team_id
+             LEFT JOIN data_product_versions v ON v.version_id = (
+                SELECT version_id FROM data_product_versions
+                WHERE data_product_id = p.product_id
+                ORDER BY version_id DESC LIMIT 1
+             )
+             ORDER BY p.product_id",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(ProductSummary {
+                product_id: row.get("product_id")?,
+                name: row.get("name")?,
+                owner_team: row.get("owner_team")?,
+                producer: row.get("producer")?,
+                created_at: row.get("created_at")?,
+                version: row.get("version_label")?,
+                asset_type: row.get("asset_type")?,
+                data_quality: row.get("data_quality")?,
+                classification: row.get("classification")?,
+                source_reference: row.get("source_path")?,
+            })
+        })?;
+
+        let query = request.query.map(|q| q.to_ascii_lowercase());
+        let owner = request.owner_team.map(|o| o.to_ascii_lowercase());
+        let asset_type = request.asset_type.map(|v| v.to_string());
+        let data_quality = request.data_quality.map(|v| v.to_string());
+        let classification = request.classification.map(|v| v.to_string());
+        let products = rows
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .filter(|product| {
+                query.as_ref().is_none_or(|query| {
+                    product.name.to_ascii_lowercase().contains(query)
+                        || product
+                            .source_reference
+                            .as_ref()
+                            .is_some_and(|s| s.to_ascii_lowercase().contains(query))
+                })
+            })
+            .filter(|product| {
+                owner
+                    .as_ref()
+                    .is_none_or(|owner| product.owner_team.to_ascii_lowercase() == *owner)
+            })
+            .filter(|product| {
+                asset_type
+                    .as_ref()
+                    .is_none_or(|value| product.asset_type.as_ref() == Some(value))
+            })
+            .filter(|product| {
+                data_quality
+                    .as_ref()
+                    .is_none_or(|value| product.data_quality.as_ref() == Some(value))
+            })
+            .filter(|product| {
+                classification
+                    .as_ref()
+                    .is_none_or(|value| product.classification.as_ref() == Some(value))
+            })
+            .collect();
+        Ok(products)
+    }
+
+    pub fn show_product(
+        &self,
+        product_ref: &str,
+        version_label: Option<&str>,
+    ) -> RegistryResult<ProductDetail> {
+        let (product, team_name) = self.resolve_product_with_team(product_ref)?;
+        let version = self.resolve_version(product.product_id, version_label)?;
+        let lineage = self.lineage_for_version(product.product_id, &version.version_label)?;
+        Ok(ProductDetail {
+            product_id: product.product_id,
+            name: product.name,
+            description: product.description,
+            owner_team: team_name,
+            producer: product.producer,
+            usage_policy: product.usage_policy,
+            intended_use: product.intended_use,
+            created_at: product.created_at.to_string(),
+            selected_version: VersionDetail {
+                version_id: version.version_id,
+                version: version.version_label,
+                asset_type: version.asset_type,
+                source_reference: version.source_path,
+                data_quality: version.data_quality,
+                classification: version.classification,
+                created_at: version.created_at.to_string(),
+            },
+            lineage,
+        })
+    }
+
+    pub fn lineage(
+        &self,
+        product_ref: &str,
+        version_label: Option<&str>,
+    ) -> RegistryResult<LineageResponse> {
+        let (product, _) = self.resolve_product_with_team(product_ref)?;
+        let version = self.resolve_version(product.product_id, version_label)?;
+        self.lineage_for_version(product.product_id, &version.version_label)
+    }
+
+    pub fn consume(&self, request: ConsumeRequest) -> RegistryResult<ConsumeReceipt> {
+        validate_version_label(&request.version)?;
+        let detail = self.show_product(&request.product_ref, Some(&request.version))?;
+        let source = PathBuf::from(&detail.selected_version.source_reference);
+        if !source.exists() {
+            return Err(RegistryError::SourceMissing(
+                detail.selected_version.source_reference,
+            ));
+        }
+        if request.out.exists() && !request.overwrite {
+            return Err(RegistryError::DestinationExists(
+                request.out.to_string_lossy().into_owned(),
+            ));
+        }
+        self.copy_source(&source, &request.out, request.overwrite)?;
+        let receipt = ConsumeReceipt {
+            product_id: detail.product_id,
+            version: detail.selected_version.version,
+            source_reference: source.to_string_lossy().into_owned(),
+            output_path: request.out.to_string_lossy().into_owned(),
+            retrieved_at: Utc::now().to_rfc3339(),
+            checksum: None,
+        };
+        let receipt_path = receipt_path(&request.out);
+        let json = serde_json::to_vec_pretty(&receipt)?;
+        fs::write(receipt_path, json).map_err(map_io_error)?;
+        Ok(receipt)
+    }
+
+    fn get_or_create_team(&self, name: &str) -> RegistryResult<Team> {
+        match TeamRepository::get_by_name(self.conn, name) {
+            Ok(team) => Ok(team),
+            Err(rusqlite::Error::QueryReturnedNoRows) => {
+                TeamRepository::create(self.conn, NewTeam::new(name.to_string()))
+                    .map_err(RegistryError::from)
+            }
+            Err(err) => Err(RegistryError::from(err)),
+        }
+    }
+
+    fn resolve_product_with_team(
+        &self,
+        product_ref: &str,
+    ) -> RegistryResult<(crate::models::DataProduct, String)> {
+        let product_id = parse_product_ref(self.conn, product_ref)?;
+        let product = DataProductRepository::get_by_id(self.conn, product_id).map_err(|err| {
+            if matches!(err, rusqlite::Error::QueryReturnedNoRows) {
+                RegistryError::NotFound(format!("product '{product_ref}'"))
+            } else {
+                RegistryError::Database(err)
+            }
+        })?;
+        let team = TeamRepository::get_by_id(self.conn, product.owner_team_id)?;
+        Ok((product, team.name))
+    }
+
+    fn resolve_version(
+        &self,
+        product_id: i64,
+        version_label: Option<&str>,
+    ) -> RegistryResult<crate::models::DataProductVersion> {
+        let result = if let Some(label) = version_label {
+            validate_version_label(label)?;
+            DataProductVersionRepository::get_by_product_and_label(self.conn, product_id, label)
+        } else {
+            DataProductVersionRepository::get_latest_for_product(self.conn, product_id)
+        };
+        result.map_err(|err| {
+            if matches!(err, rusqlite::Error::QueryReturnedNoRows) {
+                RegistryError::NotFound(format!("version for product '{product_id}'"))
+            } else {
+                RegistryError::Database(err)
+            }
+        })
+    }
+
+    fn lineage_for_version(
+        &self,
+        product_id: i64,
+        version_label: &str,
+    ) -> RegistryResult<LineageResponse> {
+        let version = DataProductVersionRepository::get_by_product_and_label(
+            self.conn,
+            product_id,
+            version_label,
+        )?;
+        let dependencies =
+            LineageDependencyRepository::get_by_downstream_version(self.conn, version.version_id)?;
+        let mut details = Vec::with_capacity(dependencies.len());
+        for dependency in dependencies {
+            let upstream = self.upstream_context(&dependency.upstream_product_uri)?;
+            details.push(LineageDependencyDetail {
+                upstream_source_reference: dependency.upstream_product_uri,
+                upstream_version: dependency.upstream_version,
+                upstream_product_id: upstream.as_ref().map(|u| u.product_id),
+                upstream_name: upstream.as_ref().map(|u| u.name.clone()),
+                upstream_producer: upstream.as_ref().map(|u| u.producer.clone()),
+                upstream_published_at: upstream.and_then(|u| u.published_at),
+            });
+        }
+        let status = if details.is_empty() {
+            "no_lineage".to_string()
+        } else {
+            "lineage_available".to_string()
+        };
+        Ok(LineageResponse {
+            product_id,
+            version: version.version_label,
+            status,
+            dependencies: details,
+        })
+    }
+
+    fn upstream_context(&self, source_path: &str) -> RegistryResult<Option<UpstreamContext>> {
+        let Some(version) =
+            DataProductVersionRepository::get_by_source_path(self.conn, source_path).optional()?
+        else {
+            return Ok(None);
+        };
+        let product = DataProductRepository::get_by_id(self.conn, version.data_product_id)?;
+        Ok(Some(UpstreamContext {
+            product_id: product.product_id,
+            name: product.name,
+            producer: product.producer,
+            published_at: Some(version.created_at.to_string()),
+        }))
+    }
+
+    fn copy_source(&self, source: &Path, out: &Path, overwrite: bool) -> RegistryResult<()> {
+        let metadata = fs::metadata(source).map_err(map_io_error)?;
+        if metadata.is_file() {
+            if overwrite && out.exists() {
+                remove_existing(out)?;
+            }
+            fs::copy(source, out).map_err(map_io_error)?;
+            return Ok(());
+        }
+        if metadata.is_dir() {
+            if overwrite && out.exists() {
+                remove_existing(out)?;
+            }
+            copy_dir_recursive(source, out)?;
+            return Ok(());
+        }
+        Err(RegistryError::Permission(format!(
+            "unsupported source type '{}'",
+            source.display()
+        )))
+    }
+}
+
+#[derive(Debug)]
+struct UpstreamContext {
+    product_id: i64,
+    name: String,
+    producer: String,
+    published_at: Option<String>,
+}
+
+fn parse_product_ref(conn: &Connection, product_ref: &str) -> RegistryResult<i64> {
+    if let Ok(product_id) = product_ref.parse::<i64>() {
+        validate_positive_id("product_id", product_id)?;
+        return Ok(product_id);
+    }
+    let version =
+        DataProductVersionRepository::get_by_source_path(conn, product_ref).map_err(|err| {
+            if matches!(err, rusqlite::Error::QueryReturnedNoRows) {
+                RegistryError::NotFound(format!("product or source path '{product_ref}'"))
+            } else {
+                RegistryError::Database(err)
+            }
+        })?;
+    Ok(version.data_product_id)
+}
+
+fn copy_dir_recursive(source: &Path, out: &Path) -> RegistryResult<()> {
+    fs::create_dir_all(out).map_err(map_io_error)?;
+    for entry in fs::read_dir(source).map_err(map_io_error)? {
+        let entry = entry.map_err(map_io_error)?;
+        let target = out.join(entry.file_name());
+        let metadata = entry.metadata().map_err(map_io_error)?;
+        if metadata.is_dir() {
+            copy_dir_recursive(&entry.path(), &target)?;
+        } else if metadata.is_file() {
+            fs::copy(entry.path(), target).map_err(map_io_error)?;
+        }
+    }
+    Ok(())
+}
+
+fn remove_existing(path: &Path) -> RegistryResult<()> {
+    let metadata = fs::metadata(path).map_err(map_io_error)?;
+    if metadata.is_dir() {
+        fs::remove_dir_all(path).map_err(map_io_error)?;
+    } else {
+        fs::remove_file(path).map_err(map_io_error)?;
+    }
+    Ok(())
+}
+
+fn receipt_path(out: &Path) -> PathBuf {
+    let file_name = out
+        .file_name()
+        .map(|name| format!("{}.feam-receipt.json", name.to_string_lossy()))
+        .unwrap_or_else(|| "feam-receipt.json".to_string());
+    out.with_file_name(file_name)
+}
+
+fn map_io_error(err: std::io::Error) -> RegistryError {
+    if err.kind() == std::io::ErrorKind::PermissionDenied {
+        RegistryError::Permission(err.to_string())
+    } else {
+        RegistryError::Filesystem(err)
     }
 }

--- a/feather-mesh/mesh_core/src/services/registry_service.rs
+++ b/feather-mesh/mesh_core/src/services/registry_service.rs
@@ -284,43 +284,60 @@ impl<'a> RegistryService<'a> {
     pub fn serve(&self, request: ServeRequest) -> RegistryResult<ServeResponse> {
         self.validate_serve_request(&request)?;
         let source = SourceReference::unix_path(request.source_path.clone())?.as_display_string();
-        let team = self.get_or_create_team(&request.owner_team)?;
-        let product = DataProductRepository::create(
-            self.conn,
-            NewDataProduct::new(
-                request.name,
-                request.description,
-                team.team_id,
-                request.producer,
-                request.usage_policy,
-                request.intended_use,
-            ),
-        )?;
-        let version = DataProductVersionRepository::create(
-            self.conn,
-            NewDataProductVersion::new(
-                product.product_id,
-                request.version,
-                request.asset_type.to_string(),
-                source.clone(),
-                request.data_quality.to_string(),
-                request.classification.to_string(),
-            ),
-        )?;
-        for lineage in request.lineage {
-            LineageDependencyRepository::create(
+        self.conn.execute_batch("BEGIN IMMEDIATE")?;
+        let result = (|| -> RegistryResult<ServeResponse> {
+            let team = self.get_or_create_team(&request.owner_team)?;
+            let product = DataProductRepository::create(
                 self.conn,
-                NewLineageDependency::new(version.version_id, lineage.source, lineage.version),
+                NewDataProduct::new(
+                    request.name,
+                    request.description,
+                    team.team_id,
+                    request.producer,
+                    request.usage_policy,
+                    request.intended_use,
+                ),
             )?;
+            let version = DataProductVersionRepository::create(
+                self.conn,
+                NewDataProductVersion::new(
+                    product.product_id,
+                    request.version,
+                    request.asset_type.to_string(),
+                    source.clone(),
+                    request.data_quality.to_string(),
+                    request.classification.to_string(),
+                ),
+            )?;
+            for lineage in request.lineage {
+                LineageDependencyRepository::create(
+                    self.conn,
+                    NewLineageDependency::new(version.version_id, lineage.source, lineage.version),
+                )?;
+            }
+            Ok(ServeResponse {
+                product_id: product.product_id,
+                version_id: version.version_id,
+                name: product.name,
+                version: version.version_label,
+                source_reference: source,
+                status: "published".to_string(),
+            })
+        })();
+
+        match result {
+            Ok(response) => {
+                if let Err(err) = self.conn.execute_batch("COMMIT") {
+                    let _ = self.conn.execute_batch("ROLLBACK");
+                    return Err(RegistryError::Database(err));
+                }
+                Ok(response)
+            }
+            Err(err) => {
+                let _ = self.conn.execute_batch("ROLLBACK");
+                Err(err)
+            }
         }
-        Ok(ServeResponse {
-            product_id: product.product_id,
-            version_id: version.version_id,
-            name: product.name,
-            version: version.version_label,
-            source_reference: source,
-            status: "published".to_string(),
-        })
     }
 
     pub fn search_products(&self, request: SearchRequest) -> RegistryResult<Vec<ProductSummary>> {
@@ -622,6 +639,11 @@ fn copy_dir_recursive(source: &Path, out: &Path) -> RegistryResult<()> {
             copy_dir_recursive(&entry.path(), &target)?;
         } else if metadata.is_file() {
             fs::copy(entry.path(), target).map_err(map_io_error)?;
+        } else {
+            return Err(RegistryError::Filesystem(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                format!("unsupported entry type at '{}'", entry.path().display()),
+            )));
         }
     }
     Ok(())

--- a/feather-mesh/mesh_core/src/services/requests.rs
+++ b/feather-mesh/mesh_core/src/services/requests.rs
@@ -1,0 +1,44 @@
+use std::path::PathBuf;
+
+use crate::domain::{AssetType, Classification, DataQuality, ValidationError};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateDataProductRequest {
+    pub name: String,
+    pub description: Option<String>,
+    pub owner_team_id: i64,
+    pub intended_use: Option<String>,
+    pub producer: String,
+    pub usage_policy: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateDataProductVersionRequest {
+    pub data_product_id: i64,
+    pub version_label: String,
+    pub asset_type: String,
+    pub source_path: String,
+    pub data_quality: String,
+    pub classification: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateLineageDependencyRequest {
+    pub downstream_version_id: i64,
+    pub upstream_product_uri: String,
+    pub upstream_version: Option<String>,
+}
+
+impl CreateDataProductVersionRequest {
+    pub fn into_serve_parts(
+        self,
+    ) -> Result<(String, AssetType, PathBuf, DataQuality, Classification), ValidationError> {
+        Ok((
+            self.version_label,
+            self.asset_type.parse()?,
+            PathBuf::from(self.source_path),
+            self.data_quality.parse()?,
+            self.classification.parse()?,
+        ))
+    }
+}

--- a/feather-mesh/mesh_core/tests/common/mod.rs
+++ b/feather-mesh/mesh_core/tests/common/mod.rs
@@ -1,0 +1,20 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub fn unique_test_db_path(prefix: &str) -> PathBuf {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("System time before UNIX EPOCH")
+        .as_nanos();
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "{prefix}_{}_{}_{}.db",
+        std::process::id(),
+        timestamp,
+        DB_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    path
+}

--- a/feather-mesh/mesh_core/tests/repository_tests.rs
+++ b/feather-mesh/mesh_core/tests/repository_tests.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+
+mod common;
 
 use mesh_core::init_db;
 use mesh_core::models::{
@@ -13,27 +13,11 @@ use mesh_core::repositories::{
 };
 use rusqlite::Connection;
 
-static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-// Builds an isolated temporary database path for each test.
-fn unique_test_db_path() -> PathBuf {
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("System time before UNIX EPOCH")
-        .as_nanos();
-    let mut path = std::env::temp_dir();
-    path.push(format!(
-        "mesh_core_repository_{}_{}_{}.db",
-        std::process::id(),
-        timestamp,
-        DB_COUNTER.fetch_add(1, Ordering::Relaxed)
-    ));
-    path
-}
+use common::unique_test_db_path;
 
 // Opens a fresh test database and applies the registry schema.
 fn test_connection() -> (Connection, PathBuf) {
-    let path = unique_test_db_path();
+    let path = unique_test_db_path("mesh_core_repository");
     let conn = init_db(&path).expect("Failed to initialize repository test database");
     (conn, path)
 }

--- a/feather-mesh/mesh_core/tests/repository_tests.rs
+++ b/feather-mesh/mesh_core/tests/repository_tests.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use mesh_core::init_db;
@@ -12,6 +13,8 @@ use mesh_core::repositories::{
 };
 use rusqlite::Connection;
 
+static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
+
 // Builds an isolated temporary database path for each test.
 fn unique_test_db_path() -> PathBuf {
     let timestamp = SystemTime::now()
@@ -19,7 +22,12 @@ fn unique_test_db_path() -> PathBuf {
         .expect("System time before UNIX EPOCH")
         .as_nanos();
     let mut path = std::env::temp_dir();
-    path.push(format!("mesh_core_repository_{}.db", timestamp));
+    path.push(format!(
+        "mesh_core_repository_{}_{}_{}.db",
+        std::process::id(),
+        timestamp,
+        DB_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
     path
 }
 
@@ -28,6 +36,47 @@ fn test_connection() -> (Connection, PathBuf) {
     let path = unique_test_db_path();
     let conn = init_db(&path).expect("Failed to initialize repository test database");
     (conn, path)
+}
+
+fn create_product_with_version(
+    conn: &Connection,
+    team_id: i64,
+    name: &str,
+    version_label: &str,
+    asset_type: &str,
+    data_quality: &str,
+    classification: &str,
+) -> (
+    mesh_core::models::DataProduct,
+    mesh_core::models::DataProductVersion,
+) {
+    let product = DataProductRepository::create(
+        conn,
+        NewDataProduct::new(
+            name.to_string(),
+            Some(format!("{name} description")),
+            team_id,
+            "Discovery Lab".to_string(),
+            "Internal use".to_string(),
+            Some(format!("{name} intended use")),
+        ),
+    )
+    .expect("Failed to create data product");
+
+    let version = DataProductVersionRepository::create(
+        conn,
+        NewDataProductVersion::new(
+            product.product_id,
+            version_label.to_string(),
+            asset_type.to_string(),
+            format!("/catalog/{name}/{version_label}"),
+            data_quality.to_string(),
+            classification.to_string(),
+        ),
+    )
+    .expect("Failed to create data product version");
+
+    (product, version)
 }
 
 #[test]
@@ -70,6 +119,8 @@ fn repositories_create_get_by_id_and_get_all_full_registry_graph() {
             "Daily Observations".to_string(),
             Some("Daily climate station observations".to_string()),
             team.team_id,
+            "Climate Lab".to_string(),
+            "Internal research use".to_string(),
             Some("Operational climate analytics".to_string()),
         ),
     )
@@ -78,6 +129,8 @@ fn repositories_create_get_by_id_and_get_all_full_registry_graph() {
     // Validate the persisted product fields, including database-managed ones.
     assert!(product.product_id > 0);
     assert_eq!(product.owner_team_id, team.team_id);
+    assert_eq!(product.producer, "Climate Lab");
+    assert_eq!(product.usage_policy, "Internal research use");
     assert_eq!(
         product.description,
         Some("Daily climate station observations".to_string())
@@ -100,8 +153,8 @@ fn repositories_create_get_by_id_and_get_all_full_registry_graph() {
             "v1.0.0".to_string(),
             "table".to_string(),
             "/project/feather-mesh/climate/daily".to_string(),
-            "gold".to_string(),
-            Some("internal".to_string()),
+            "production".to_string(),
+            "internal".to_string(),
         ),
     )
     .expect("Failed to create data product version");
@@ -109,7 +162,7 @@ fn repositories_create_get_by_id_and_get_all_full_registry_graph() {
     // Validate the persisted version fields, including database-managed ones.
     assert!(version.version_id > 0);
     assert_eq!(version.data_product_id, product.product_id);
-    assert_eq!(version.classification, Some("internal".to_string()));
+    assert_eq!(version.classification, "internal");
 
     // get_by_id returns the same version by primary key.
     let found_version = DataProductVersionRepository::get_by_id(&conn, version.version_id)
@@ -188,7 +241,14 @@ fn repositories_preserve_none_for_nullable_insert_fields() {
         .expect("Failed to create team");
     let product = DataProductRepository::create(
         &conn,
-        NewDataProduct::new("Bare Product".to_string(), None, team.team_id, None),
+        NewDataProduct::new(
+            "Bare Product".to_string(),
+            None,
+            team.team_id,
+            "Minimal Team".to_string(),
+            "Internal use".to_string(),
+            None,
+        ),
     )
     .expect("Failed to create data product");
     let version = DataProductVersionRepository::create(
@@ -198,8 +258,8 @@ fn repositories_preserve_none_for_nullable_insert_fields() {
             "v1".to_string(),
             "file".to_string(),
             "/tmp/data.csv".to_string(),
-            "bronze".to_string(),
-            None,
+            "unverified".to_string(),
+            "internal".to_string(),
         ),
     )
     .expect("Failed to create version");
@@ -217,12 +277,70 @@ fn repositories_preserve_none_for_nullable_insert_fields() {
     // Nullable insert fields should round trip as None when omitted.
     assert_eq!(product.description, None);
     assert_eq!(product.intended_use, None);
-    assert_eq!(version.classification, None);
+    assert_eq!(version.classification, "internal");
     assert_eq!(metadata.namespace, None);
     assert_eq!(metadata.meta_value, None);
     assert_eq!(metadata.value_type, None);
     assert_eq!(dependency.upstream_version, None);
 
     // Remove the temporary database file.
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn discovery_queries_return_case_insensitive_matches_with_current_metadata_values() {
+    let (conn, path) = test_connection();
+    let team = TeamRepository::create(&conn, NewTeam::new("Discovery".to_string()))
+        .expect("Failed to create team");
+    let (product, version) = create_product_with_version(
+        &conn,
+        team.team_id,
+        "River Gauge Feed",
+        "v1",
+        "Table",
+        "Production",
+        "Internal",
+    );
+    create_product_with_version(
+        &conn,
+        team.team_id,
+        "Weather Alerts",
+        "v1",
+        "report_artifact",
+        "unverified",
+        "public",
+    );
+
+    assert_eq!(
+        DataProductRepository::get_all_by_asset_type(&conn, "table")
+            .expect("Failed asset type discovery"),
+        vec![product.clone()]
+    );
+    assert_eq!(
+        DataProductRepository::get_all_by_data_quality(&conn, "production")
+            .expect("Failed quality discovery"),
+        vec![product.clone()]
+    );
+    assert_eq!(
+        DataProductRepository::get_all_by_classification(&conn, "internal")
+            .expect("Failed classification discovery"),
+        vec![product.clone()]
+    );
+    assert_eq!(
+        DataProductVersionRepository::get_all_by_asset_type(&conn, "table")
+            .expect("Failed version asset type discovery"),
+        vec![version.clone()]
+    );
+    assert_eq!(
+        DataProductVersionRepository::get_all_by_data_quality(&conn, "production")
+            .expect("Failed version quality discovery"),
+        vec![version.clone()]
+    );
+    assert_eq!(
+        DataProductVersionRepository::get_all_by_classification(&conn, "internal")
+            .expect("Failed version classification discovery"),
+        vec![version]
+    );
+
     fs::remove_file(path).ok();
 }

--- a/feather-mesh/mesh_core/tests/service_tests.rs
+++ b/feather-mesh/mesh_core/tests/service_tests.rs
@@ -1,10 +1,17 @@
 use std::fs;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use mesh_core::domain::RegistryError;
 use mesh_core::init_db;
-use mesh_core::services::RegistryService;
+use mesh_core::services::{
+    CreateDataProductRequest, CreateDataProductVersionRequest, CreateLineageDependencyRequest,
+    RegistryService,
+};
 use rusqlite::Connection;
+
+static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 // Builds an isolated temporary database path for each test.
 fn unique_test_db_path() -> PathBuf {
@@ -13,7 +20,12 @@ fn unique_test_db_path() -> PathBuf {
         .expect("System time before UNIX EPOCH")
         .as_nanos();
     let mut path = std::env::temp_dir();
-    path.push(format!("mesh_core_service_{}.db", timestamp));
+    path.push(format!(
+        "mesh_core_service_{}_{}_{}.db",
+        std::process::id(),
+        timestamp,
+        DB_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
     path
 }
 
@@ -39,6 +51,98 @@ fn registry_service_registers_and_lists_teams() {
 
     let teams = service.list_teams().expect("Failed to list teams");
     assert_eq!(teams, vec![team]);
+
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn registry_service_compatibility_methods_register_product_version_and_lineage() {
+    let (conn, path) = test_connection();
+    let service = RegistryService::new(&conn);
+    let team = service
+        .register_team("Climate".to_string())
+        .expect("Failed to register team");
+
+    let product = service
+        .register_data_product(CreateDataProductRequest {
+            name: "Daily Observations".to_string(),
+            description: Some("Daily climate station observations".to_string()),
+            owner_team_id: team.team_id,
+            intended_use: Some("Operational climate analytics".to_string()),
+            producer: "Climate Lab".to_string(),
+            usage_policy: "Internal research use".to_string(),
+        })
+        .expect("Failed to register product");
+
+    let version = service
+        .register_data_product_version(CreateDataProductVersionRequest {
+            data_product_id: product.product_id,
+            version_label: "v1.0.0".to_string(),
+            asset_type: "model-artifact".to_string(),
+            source_path: "/tmp/data with spaces/model.bin".to_string(),
+            data_quality: "production".to_string(),
+            classification: "internal".to_string(),
+        })
+        .expect("Failed to register version");
+
+    assert_eq!(version.asset_type, "model_artifact");
+    assert_eq!(version.source_path, "/tmp/data with spaces/model.bin");
+
+    let dependency = service
+        .register_lineage_dependency(CreateLineageDependencyRequest {
+            downstream_version_id: version.version_id,
+            upstream_product_uri: "/tmp/upstream with spaces.csv".to_string(),
+            upstream_version: Some("v2".to_string()),
+        })
+        .expect("Failed to register lineage");
+    assert_eq!(dependency.downstream_version_id, version.version_id);
+
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn registry_service_compatibility_methods_reject_missing_owner_and_legacy_quality() {
+    let (conn, path) = test_connection();
+    let service = RegistryService::new(&conn);
+
+    let missing_owner = service
+        .register_data_product(CreateDataProductRequest {
+            name: "Daily Observations".to_string(),
+            description: None,
+            owner_team_id: 404,
+            intended_use: None,
+            producer: "Climate Lab".to_string(),
+            usage_policy: "Internal".to_string(),
+        })
+        .expect_err("missing owner should fail");
+    assert!(matches!(missing_owner, RegistryError::NotFound(message) if message.contains("404")));
+
+    let team = service
+        .register_team("Climate".to_string())
+        .expect("Failed to register team");
+    let product = service
+        .register_data_product(CreateDataProductRequest {
+            name: "Daily Observations".to_string(),
+            description: None,
+            owner_team_id: team.team_id,
+            intended_use: None,
+            producer: "Climate Lab".to_string(),
+            usage_policy: "Internal".to_string(),
+        })
+        .expect("Failed to register product");
+    let invalid_quality = service
+        .register_data_product_version(CreateDataProductVersionRequest {
+            data_product_id: product.product_id,
+            version_label: "v1".to_string(),
+            asset_type: "file".to_string(),
+            source_path: "/tmp/daily.csv".to_string(),
+            data_quality: "gold".to_string(),
+            classification: "internal".to_string(),
+        })
+        .expect_err("legacy quality should fail");
+    assert!(
+        matches!(invalid_quality, RegistryError::Validation(error) if error.field == "DataQuality")
+    );
 
     fs::remove_file(path).ok();
 }

--- a/feather-mesh/mesh_core/tests/service_tests.rs
+++ b/feather-mesh/mesh_core/tests/service_tests.rs
@@ -1,37 +1,21 @@
 use std::fs;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 
-use mesh_core::domain::RegistryError;
+mod common;
+
+use mesh_core::domain::{AssetType, Classification, DataQuality, RegistryError};
 use mesh_core::init_db;
 use mesh_core::services::{
     CreateDataProductRequest, CreateDataProductVersionRequest, CreateLineageDependencyRequest,
-    RegistryService,
+    RegistryService, ServeRequest,
 };
 use rusqlite::Connection;
 
-static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-// Builds an isolated temporary database path for each test.
-fn unique_test_db_path() -> PathBuf {
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("System time before UNIX EPOCH")
-        .as_nanos();
-    let mut path = std::env::temp_dir();
-    path.push(format!(
-        "mesh_core_service_{}_{}_{}.db",
-        std::process::id(),
-        timestamp,
-        DB_COUNTER.fetch_add(1, Ordering::Relaxed)
-    ));
-    path
-}
+use common::unique_test_db_path;
 
 // Opens a fresh test database and applies the registry schema.
 fn test_connection() -> (Connection, PathBuf) {
-    let path = unique_test_db_path();
+    let path = unique_test_db_path("mesh_core_service");
     let conn = init_db(&path).expect("Failed to initialize service test database");
     (conn, path)
 }
@@ -141,8 +125,65 @@ fn registry_service_compatibility_methods_reject_missing_owner_and_legacy_qualit
         })
         .expect_err("legacy quality should fail");
     assert!(
-        matches!(invalid_quality, RegistryError::Validation(error) if error.field == "DataQuality")
+        matches!(invalid_quality, RegistryError::Validation(error) if error.field == "data_quality")
     );
+
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn registry_service_serve_rolls_back_product_when_version_insert_fails() {
+    let (conn, path) = test_connection();
+    let service = RegistryService::new(&conn);
+    let source_path = PathBuf::from("/tmp/shared-source.csv");
+
+    service
+        .serve(ServeRequest {
+            source_path: source_path.clone(),
+            name: "Published Product".to_string(),
+            asset_type: AssetType::File,
+            version: "v1".to_string(),
+            owner_team: "Climate".to_string(),
+            producer: "Climate Lab".to_string(),
+            usage_policy: "Internal".to_string(),
+            data_quality: DataQuality::Production,
+            classification: Classification::Internal,
+            description: None,
+            intended_use: None,
+            lineage: vec![],
+        })
+        .expect("initial serve should succeed");
+
+    let duplicate = service
+        .serve(ServeRequest {
+            source_path,
+            name: "Rolled Back Product".to_string(),
+            asset_type: AssetType::File,
+            version: "v1".to_string(),
+            owner_team: "Rollback Team".to_string(),
+            producer: "Climate Lab".to_string(),
+            usage_policy: "Internal".to_string(),
+            data_quality: DataQuality::Production,
+            classification: Classification::Internal,
+            description: None,
+            intended_use: None,
+            lineage: vec![],
+        })
+        .expect_err("duplicate source path should fail");
+    assert!(matches!(duplicate, RegistryError::Database(_)));
+
+    let product_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM data_products", [], |row| row.get(0))
+        .expect("Failed to count products");
+    let rollback_team_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM teams WHERE name = 'Rollback Team'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("Failed to count rollback team");
+    assert_eq!(product_count, 1);
+    assert_eq!(rollback_team_count, 0);
 
     fs::remove_file(path).ok();
 }


### PR DESCRIPTION
## Purpose

Implement the Rust `mesh_cli` as the `feam` command-line surface described by the CLI workplan and PRD. This turns the placeholder CLI into a working local SQLite-backed workflow for publishing, discovering, inspecting, tracing lineage for, validating, and consuming Feather Mesh data products.

## Change List

- Replaced the placeholder `mesh_cli` entry point with `clap`-based command parsing for `init`, `serve`, `search`, `show`, `consume`, `lineage`, `validate-metadata`, `teams`, and `products`.
- Added global CLI options for `--registry`, `--format <table|json>`, and `--verbose`.
- Added core domain validation for asset type, data quality, classification, product names, version labels, IDs, optional text, and filesystem source references.
- Expanded the SQLite schema and models to include product-level `producer` and `usage_policy`, and required version-level `classification`.
- Added service-layer DTOs and workflows for serve/search/show/lineage/consume/metadata validation while keeping terminal formatting and exit-code mapping in `mesh_cli`.
- Added managed-copy consumption for files and directories with `.feam-receipt.json` receipt output.
- Added repository helpers for source-path lookup, version lookup, lineage lookup, team lookup, and current metadata discovery filters.
- Added CLI integration tests for the primary demo workflow, JSON output, receipt creation, and stable validation/not-found/policy exit codes.
- Updated Rust workspace manifests, lockfile, and README usage examples.

## Absorbed Deprecated Open PRs

This branch intentionally absorbs the useful behavior from the two older clashing feature branches so those branches do not need to be merged directly.

- `implement-keystone-metadata-domain-validation`
  - Preserved typed metadata validation through `mesh_core::domain`.
  - Preserved field-specific validation coverage for invalid product names, version labels, blank fields, invalid enum values, and legacy quality values such as `gold`/`silver`/`bronze`.
  - Preserved enum normalization behavior for hyphenated input such as `model-artifact` -> `model_artifact`.
  - Did not preserve the old source-path whitespace rejection because the accepted workplan requires preserving filesystem paths with spaces.
  - Did not preserve the older `models::metadata::*` module split because the current implementation centralizes domain validation in `mesh_core::domain`.

- `data-product-registration-workflow`
  - Preserved the service-layer registration concept with compatibility DTOs and methods: `register_data_product`, `register_data_product_version`, and `register_lineage_dependency`.
  - Preserved missing-owner validation coverage, but adapted it to the current `RegistryError` model and expanded required metadata.
  - Did not preserve the older narrow API shape because the implemented CLI workflow requires `producer`, `usage_policy`, typed version metadata, source references, and owner-team lookup/create behavior.

## Validation

- `cargo fmt`
- `cargo test`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full `feam` CLI with global options, subcommands, and table/JSON output.
  * Enhanced discovery and listing with filtering by asset type, data quality, and classification.
  * Enforced required metadata during registration (including producer, usage policy, and classification) and improved lineage/consume receipt output.
* **Bug Fixes**
  * Improved registry schema evolution with safe backfills, stricter constraints, and added indexing.
  * Fixed/covered multibyte text truncation in table output and stabilized exit codes.
* **Documentation**
  * Updated README with CLI examples and exit-code meanings.
  * Added V1 PDD and project exit-outcomes documents.
* **Tests**
  * Added end-to-end CLI workflow and additional validation/stability tests; improved test isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->