### PR TITLE
[codex] Add AI-SDLC agent context

### DIFF
--- a/.codex/skills/feam-agent-context-maintainer/SKILL.md
+++ b/.codex/skills/feam-agent-context-maintainer/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: feam-agent-context-maintainer
+description: Use when AGENTS.md is missing, stale, contradictory, or needs self-healing; when repo structure, Cargo workspace layout, CI, commands, tests, or source-of-truth docs change; or when asked to update Feather Mesh AI-SDLC, agent, onboarding, or project skill context.
+---
+
+# Feather Mesh Agent Context Maintainer
+
+Use this skill to keep project agent context small, accurate, and durable.
+
+## Sources To Read
+
+Read only the high-signal files needed for the drift being investigated:
+
+- `AGENTS.md`
+- `README.md`
+- `feather-mesh/README.md`
+- `feather-mesh/Cargo.toml`
+- `.github/workflows/rust.yml`
+- Changed files relevant to the current task
+
+Do not load long project artifacts, PDFs, generated outputs, or the Python MVP unless the task specifically targets them.
+
+## Self-Healing Rules
+
+- Patch `AGENTS.md` when it is missing, stale, or contradicted by durable repo facts.
+- Keep `AGENTS.md` as a routing and decision guide, not a duplicate README.
+- Prefer durable facts: source-of-truth directories, crate boundaries, validation commands, tested contracts, and ownership rules.
+- Remove stale statements instead of adding caveats around them.
+- Keep the file concise; target under 120 lines.
+- Do not include temporary branch status, implementation plans, sprint notes, or speculative roadmap.
+- Keep Python MVP context explicitly secondary unless it becomes the active implementation source of truth.
+
+## Drift Check
+
+When useful, run:
+
+```bash
+.codex/skills/feam-agent-context-maintainer/scripts/check_agents_context.sh
+```
+
+Treat the script as a smoke check. Passing does not prove the context is complete; it only verifies the most important anchors exist.
+
+## Validation
+
+After updating context, verify that a future agent could answer:
+
+- Where should a CLI behavior change go?
+- What tests should run after service logic changes?
+- Is `python_mvp/` the source of truth?
+- Where are stable CLI exit codes documented and tested?

--- a/.codex/skills/feam-agent-context-maintainer/scripts/check_agents_context.sh
+++ b/.codex/skills/feam-agent-context-maintainer/scripts/check_agents_context.sh
@@ -9,6 +9,7 @@ if [[ ! -f "$file" ]]; then
 fi
 
 required_patterns=(
+  "feam"
   "feather-mesh/"
   "mesh_core"
   "mesh_cli"

--- a/.codex/skills/feam-agent-context-maintainer/scripts/check_agents_context.sh
+++ b/.codex/skills/feam-agent-context-maintainer/scripts/check_agents_context.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="AGENTS.md"
+
+if [[ ! -f "$file" ]]; then
+  echo "missing AGENTS.md" >&2
+  exit 1
+fi
+
+required_patterns=(
+  "feather-mesh/"
+  "mesh_core"
+  "mesh_cli"
+  "cargo test"
+  "python_mvp/"
+  "not be treated as the primary implementation"
+)
+
+for pattern in "${required_patterns[@]}"; do
+  if ! grep -Fq "$pattern" "$file"; then
+    echo "AGENTS.md missing required context: $pattern" >&2
+    exit 1
+  fi
+done
+
+if grep -Eiq "python_mvp/ is (the )?(primary|source of truth)|primary implementation lives in python_mvp/|source of truth.+python_mvp/" "$file"; then
+  echo "AGENTS.md appears to make python_mvp primary; review required" >&2
+  exit 1
+fi
+
+echo "AGENTS.md context smoke check passed"

--- a/.codex/skills/feam-cli-contract/SKILL.md
+++ b/.codex/skills/feam-cli-contract/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: feam-cli-contract
+description: Use when changing or reviewing Feather Mesh CLI behavior, feam commands, command flags, output formatting, JSON/table responses, user-facing errors, exit codes, or CLI workflow tests.
+---
+
+# Feather Mesh CLI Contract
+
+Use this skill for user-facing `feam` behavior.
+
+## Contract
+
+- The user-facing command is `feam`.
+- The Rust package and binary crate remain `mesh_cli`.
+- Keep command parsing, terminal UX, output formatting, and process exit behavior in `feather-mesh/mesh_cli`.
+- Keep business rules and persistence workflows behind `mesh_core::services`.
+
+Implemented commands:
+
+- `init`
+- `serve`
+- `search`
+- `show`
+- `consume`
+- `lineage`
+- `validate-metadata`
+- `teams`
+- `products`
+
+## Change Rules
+
+- Preserve command names, flag names, JSON field names, and exit-code meanings unless the user explicitly requests a contract change.
+- When changing output, check both table and JSON behavior if both are affected.
+- When changing errors, verify the mapped exit code still matches `feather-mesh/README.md`.
+- Prefer adding CLI workflow coverage in `feather-mesh/mesh_cli/tests/cli_workflow_tests.rs` for externally visible behavior.
+- Add service-level tests when the CLI change exposes new `mesh_core` behavior.
+
+## Validation
+
+For focused CLI iteration, run from `feather-mesh/`:
+
+```bash
+cargo test -p mesh_cli
+```
+
+For contract-sensitive changes, also run:
+
+```bash
+cargo fmt -- --check
+cargo clippy -- -D warnings
+cargo test
+```

--- a/.codex/skills/feam-rust-workflow/SKILL.md
+++ b/.codex/skills/feam-rust-workflow/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: feam-rust-workflow
+description: Use when making Rust implementation changes in Feather Mesh, including mesh_core or mesh_cli edits, repository/service/domain changes, tests, refactors, build failures, clippy failures, or cargo workflow work.
+---
+
+# Feather Mesh Rust Workflow
+
+Use this skill for Rust work in the `feather-mesh/` workspace.
+
+## Orientation
+
+- Work from `feather-mesh/` for Cargo commands.
+- `mesh_core` owns domain types, SQLite setup, repositories, services, and reusable workflow behavior.
+- `mesh_cli` owns CLI parsing, terminal output, JSON/table formatting, and process exit behavior.
+- The root-level `python_mvp/` is historical prototype context unless the user explicitly asks for Python MVP work.
+
+## Change Workflow
+
+1. Read `AGENTS.md` first if it has not already been loaded.
+2. Inspect the affected crate boundary before editing.
+3. Keep edits scoped to the layer that owns the behavior:
+   - CLI command surface or output: `mesh_cli`.
+   - Business workflow, validation orchestration, or API-style behavior: `mesh_core::services`.
+   - Domain enums, validation primitives, and shared errors: `mesh_core::domain`.
+   - SQL and row mapping: `mesh_core::repositories`.
+4. Add or update tests at the closest useful level.
+5. Run focused checks first, then broaden if the change crosses boundaries.
+
+## Validation
+
+Use the narrowest check while iterating:
+
+```bash
+cargo test -p mesh_core
+cargo test -p mesh_cli
+```
+
+Before finishing material Rust changes, run from `feather-mesh/`:
+
+```bash
+cargo fmt -- --check
+cargo clippy -- -D warnings
+cargo test
+```
+
+If a command cannot be run, report the reason and the residual risk.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Agent Context
+
+Feather Mesh is an HPC-oriented data catalog and data mesh project. The current implementation lives in `feather-mesh/` as a Rust workspace. `python_mvp/` is an earlier prototype and should not be treated as the primary implementation unless the task explicitly targets it.
+
+## Primary Implementation
+
+- `feather-mesh/mesh_core`: shared Rust library for domain types, SQLite setup, repositories, and service workflows.
+- `feather-mesh/mesh_cli`: `feam` command-line interface built on `mesh_core`.
+- Run Rust commands from `feather-mesh/`.
+
+## Validation
+
+Before finishing Rust changes, run the narrowest useful checks, then broaden as risk increases:
+
+- `cargo fmt -- --check`
+- `cargo clippy -- -D warnings`
+- `cargo test`
+
+Use `cargo test -p mesh_core` or `cargo test -p mesh_cli` for focused iteration.
+
+## CLI Contract
+
+The user-facing command is `feam`. The package and binary crate are still named `mesh_cli`.
+
+Implemented commands:
+
+- `init`
+- `serve`
+- `search`
+- `show`
+- `consume`
+- `lineage`
+- `validate-metadata`
+- `teams`
+- `products`
+
+Stable exit codes are documented in `feather-mesh/README.md` and tested in `feather-mesh/mesh_cli/tests/cli_workflow_tests.rs`.
+
+## Engineering Rules
+
+- Keep CLI parsing, terminal output, process exit behavior, and user-facing formatting in `mesh_cli`.
+- Keep business workflows in `mesh_core::services`.
+- Keep SQL and row mapping in `mesh_core::repositories`.
+- Add or update tests for CLI behavior, service behavior, validation, persistence, or exit-code changes.
+- Do not use the Python MVP as source of truth for Rust behavior.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This STRK-Solutions repository contains the capstone work for Feather Mesh, an H
 
 This root README is intentionally high level. For setup, usage, and implementation details, use the README inside each subproject directory.
 
+For agent-specific repository guidance, use [`AGENTS.md`](/AGENTS.md). Keep that file concise and focused on durable project context, crate boundaries, and validation rules.
+
 ## Repository Overview
 
 ### `python_mvp/`


### PR DESCRIPTION
## Summary

- Add a concise root `AGENTS.md` with durable project context, Rust workspace boundaries, validation commands, and CLI contract notes.
- Add project-specific Codex skills for Rust workflow, CLI contract changes, and self-healing agent context maintenance.
- Add an executable context smoke-check script and link the root README to `AGENTS.md`.

## Impact

This gives future coding agents a small, high-signal entrypoint for Feather Mesh work and a project-specific workflow for keeping that context current as the repo changes.

## Validation

- `.codex/skills/feam-agent-context-maintainer/scripts/check_agents_context.sh`

Rust cargo checks were not run because this change only adds agent context, skills, and documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contributor and agent guidance in the main repository instructions, including Rust workflow conventions and validation commands.
  * Expanded the top-level README with a direct link to the guidance document.
  * Documented the user-facing `feam` CLI contract (supported commands, flags, exit codes) and a Rust workflow for the workspace.
* **Chores**
  * Added a repository “context smoke check” script to verify the `AGENTS.md` guidance is present and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->